### PR TITLE
fix(pipeline) : Stop 1jeune1solution crash

### DIFF
--- a/pipeline/dags/dag_utils/settings.py
+++ b/pipeline/dags/dag_utils/settings.py
@@ -109,14 +109,12 @@ SOURCES_CONFIGS = [
             {
                 "id": "benefits",
                 "filename": "benefits.json",
-                "url": Variable.get("UN_JEUNE_UNE_SOLUTION_API_URL", None).rstrip("/")
-                + "/benefits",
+                "url": Variable.get("UN_JEUNE_UNE_SOLUTION_API_URL", None),
             },
             {
                 "id": "institutions",
                 "filename": "institutions.json",
-                "url": Variable.get("UN_JEUNE_UNE_SOLUTION_API_URL", None).rstrip("/")
-                + "/institutions",
+                "url": Variable.get("UN_JEUNE_UNE_SOLUTION_API_URL", None),
             },
         ],
     },

--- a/pipeline/src/data_inclusion/scripts/tasks/un_jeune_une_solution.py
+++ b/pipeline/src/data_inclusion/scripts/tasks/un_jeune_une_solution.py
@@ -2,4 +2,4 @@ from data_inclusion.scripts.tasks import utils
 
 
 def extract(id: str, url: str, **kwargs) -> bytes:
-    return utils.extract_http_content(url.rstrip("/") + "/" + id)
+    return utils.extract_http_content(utils.safe_urljoin(url, id))

--- a/pipeline/src/data_inclusion/scripts/tasks/utils.py
+++ b/pipeline/src/data_inclusion/scripts/tasks/utils.py
@@ -2,12 +2,17 @@ import io
 import logging
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urljoin
 
 import numpy as np
 import pandas as pd
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+def safe_urljoin(base, path):
+    return urljoin(base, path) if base is not None else None
 
 
 def log_df_info(df: pd.DataFrame, logger: logging.Logger = logger):


### PR DESCRIPTION
Le dernier commit introduit en #169 ajoute deux fois le nom de l'endpoint, ce qui finit en 404.

De plus les settings continuent de crasher dans les tests de DAGs car le `rstrip` ne fait pas de check préliminaire.

Ceci permet à la fois de re-simplifier le load et de corriger les deux soucis d'un coup.