### PR TITLE
chore(pipeline) : Enable post-deploy migration on demand

### DIFF
--- a/pipeline/entrypoint.sh
+++ b/pipeline/entrypoint.sh
@@ -30,12 +30,14 @@ export AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://data-inclusion-lake/logs
 export AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=s3_logs
 export AIRFLOW__LOGGING__DELETE_LOCAL_LOGS=True
 
-if [[ "${COMMAND}" = "webserver" ]]; then
-    airflow webserver --port "${PORT}"
+# migrate is run as post-deploy hook, but sometimes we also want to migrate
+# before the deployment.
+if [[ "${COMMAND}" = "migrate" ]] || [[ "${_AIRFLOW_DB_MIGRATE}" = "true" ]]; then
+    airflow db migrate
 fi
 
-if [[ "${COMMAND}" = "migrate" ]]; then
-    airflow db migrate
+if [[ "${COMMAND}" = "webserver" ]]; then
+    airflow webserver --port "${PORT}"
 fi
 
 if [[ "${COMMAND}" = "scheduler" ]]; then


### PR DESCRIPTION
Permet de relancer les migrations avant chaque mise à jour de Airflow.

On ne peut pas vraiment faire autrement car meme avec un `scalingo run` on peut ne pas tomber sur les bonnes migrations Sqlalchemy, qui sont tagguées avec des hashes.

Exemple:
```
> pip install apache-airflow==2.8.4
[...]
> AIRFLOW__DATABASE__SQL_ALCHEMY_CONN='postgresql://xxx' airflow db migrate
[...]
alembic.script.revision.ResolutionError: No such revision or branch '0c9e8a379aa6'
```

Avec ce modèle, on peut lancer les migration pre-deploy en mettant à jour une variable d'environnement.

Testé en local.

On peut aller plus loin en:
- retirant la cible `airflow-init` dans nos `docker-compose.yml` qui devient presque redondante, mais peut servir à créer le premier user aussi
- retirant le post-deploy `migrate` puisque de toutes façons Airflow effectue ses migrations plutôt AVANT le déploiement (sauf cleanup)
