### PR TITLE
fix(deployment) : Make the image and container prune work

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -198,8 +198,8 @@ resource "null_resource" "up" {
 
   provisioner "remote-exec" {
     inline = [
-      "docker image prune --all --force --filter 'until=7d'",
-      "docker container prune --force --filter 'until=7d'",
+      "docker image prune --all --force --filter 'until=168h'",
+      "docker container prune --force --filter 'until=168h'",
       "cd ${local.work_dir}",
       "docker compose --progress=plain up --pull=always --force-recreate --remove-orphans --wait --wait-timeout 1200 --quiet-pull --detach",
       # FIXME: ideally this file should be removed


### PR DESCRIPTION
The command was ignored since for some reason, and contrary to what the documentation indicates
(https://docs.docker.com/reference/cli/docker/image/prune/#filter)

... we can't use *any* Go duration string. "7d" is invalid.

Replace it with the hour-based version, which works.