### PR TITLE
feat(api): add session id header

### DIFF
--- a/api/src/alembic/versions/20240409_180006_84d303fbb413_session_id.py
+++ b/api/src/alembic/versions/20240409_180006_84d303fbb413_session_id.py
@@ -1,0 +1,24 @@
+"""Session id
+
+Revision ID: 84d303fbb413
+Revises: 14252f787143
+Create Date: 2024-04-09 18:00:06.160213
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "84d303fbb413"
+down_revision = "14252f787143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api__requests", sa.Column("session_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api__requests", "session_id")

--- a/api/src/data_inclusion/api/inclusion_data/routes.py
+++ b/api/src/data_inclusion/api/inclusion_data/routes.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from typing import Annotated, TypeVar
 
 from furl import furl
@@ -28,6 +29,21 @@ T = TypeVar("T")
 Optional = T | SkipJsonSchema[None]
 
 
+SessionIdHeader = Annotated[
+    str | None,
+    fastapi.Header(
+        alias="session-id",
+        description=dedent(
+            """\
+            Un identifiant de session utilisateur unique sur votre produit.
+            Cet identifiant doit être généré par vos soins et anonymisé.
+            Utilisé par data·inclusion exclusivement à des fins d'analyse d'usage.
+        """,
+        ),
+    ),
+]
+
+
 @router.get(
     "/structures",
     response_model=pagination.Page[schemas.Structure],
@@ -37,6 +53,7 @@ Optional = T | SkipJsonSchema[None]
 )
 def list_structures_endpoint(
     request: fastapi.Request,
+    session_id: SessionIdHeader = None,
     source: Annotated[Optional[str], fastapi.Query()] = None,
     id: Annotated[Optional[str], fastapi.Query()] = None,
     typologie: Annotated[Optional[di_schema.Typologie], fastapi.Query()] = None,
@@ -45,9 +62,7 @@ def list_structures_endpoint(
     ] = None,
     thematique: Annotated[Optional[di_schema.Thematique], fastapi.Query()] = None,
     departement: Annotated[Optional[DepartementCOG], fastapi.Query()] = None,
-    departement_slug: Annotated[
-        Optional[DepartementSlug], fastapi.Query()
-    ] = None,
+    departement_slug: Annotated[Optional[DepartementSlug], fastapi.Query()] = None,
     code_postal: Annotated[Optional[di_schema.CodePostal], fastapi.Query()] = None,
     db_session=fastapi.Depends(db.get_session),
 ):
@@ -74,6 +89,7 @@ def list_structures_endpoint(
 def retrieve_structure_endpoint(
     source: Annotated[str, fastapi.Path()],
     id: Annotated[str, fastapi.Path()],
+    session_id: SessionIdHeader = None,
     db_session=fastapi.Depends(db.get_session),
     _=fastapi.Depends(soliguide.notify_soliguide_dependency),
 ):
@@ -88,6 +104,7 @@ def retrieve_structure_endpoint(
 )
 def list_sources_endpoint(
     request: fastapi.Request,
+    session_id: SessionIdHeader = None,
 ):
     return services.list_sources(request=request)
 
@@ -101,13 +118,12 @@ def list_sources_endpoint(
 )
 def list_services_endpoint(
     request: fastapi.Request,
+    session_id: SessionIdHeader = None,
     db_session=fastapi.Depends(db.get_session),
     source: Annotated[Optional[str], fastapi.Query()] = None,
     thematique: Annotated[Optional[di_schema.Thematique], fastapi.Query()] = None,
     departement: Annotated[Optional[DepartementCOG], fastapi.Query()] = None,
-    departement_slug: Annotated[
-        Optional[DepartementSlug], fastapi.Query()
-    ] = None,
+    departement_slug: Annotated[Optional[DepartementSlug], fastapi.Query()] = None,
     code_insee: Annotated[Optional[di_schema.CodeCommune], fastapi.Query()] = None,
 ):
     return services.list_services(
@@ -130,6 +146,7 @@ def list_services_endpoint(
 def retrieve_service_endpoint(
     source: Annotated[str, fastapi.Path()],
     id: Annotated[str, fastapi.Path()],
+    session_id: SessionIdHeader = None,
     db_session=fastapi.Depends(db.get_session),
     _=fastapi.Depends(soliguide.notify_soliguide_dependency),
 ):
@@ -145,6 +162,7 @@ def redirect_service_endpoint(
     source: Annotated[str, fastapi.Path()],
     id: Annotated[str, fastapi.Path()],
     depuis: Annotated[str, fastapi.Query()],
+    session_id: SessionIdHeader = None,
     db_session=fastapi.Depends(db.get_session),
 ):
     """Redirige vers le lien source du service donné"""
@@ -183,6 +201,7 @@ def redirect_service_endpoint(
 def search_services_endpoint(
     request: fastapi.Request,
     db_session=fastapi.Depends(db.get_session),
+    session_id: SessionIdHeader = None,
     source: Annotated[
         Optional[str],
         fastapi.Query(

--- a/api/src/data_inclusion/api/request/models.py
+++ b/api/src/data_inclusion/api/request/models.py
@@ -17,6 +17,7 @@ class Request(db.Base):
     client_host: Mapped[str | None]
     client_port: Mapped[int | None]
     endpoint_name: Mapped[str | None]
+    session_id: Mapped[str | None]
 
     __table_args__ = (
         sqla.Index(None, "endpoint_name"),

--- a/api/src/data_inclusion/api/request/services.py
+++ b/api/src/data_inclusion/api/request/services.py
@@ -41,6 +41,7 @@ def save_request(
         client_host=request.client.host if request.client is not None else None,
         client_port=request.client.port if request.client is not None else None,
         endpoint_name=endpoint_name,
+        session_id=request.headers.get("session-id"),
     )  # type: ignore
 
     db_session.add(request_instance)


### PR DESCRIPTION
* est-ce qu'on ne voudrait pas générer nous même ce session id ? (e.g. s'il n'est pas fourni en header)
* ce qu'on veut c'est un session id par session utilisateur, donc un produit consommateur devrait en quelques sorte distinguer les sessions de ses utilisateurs quand parle avec notre api
* est-ce que ça ne réinvente pas la roue/un flow finalement ?