### PR TITLE
fix(api): ensure valid db url scheme

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -6,6 +6,13 @@ set -e
 # Trace execution
 [[ "${DEBUG}" ]] && set -x
 
+# The `DATABASE_URL` env var is automatically set by Scalingo.
+# It uses the depreciated scheme `postgres://`.
+# Fixing the env variable from the UI is not enough,
+# because when upgrading the database, Scalingo overwrites it.
+# The following line fixes the scheme at runtime.
+export DATABASE_URL="${DATABASE_URL/postgres\:\/\//postgresql\:\/\/}"
+
 gunicorn data_inclusion.api.app:app \
     --workers 4 \
     --worker-class uvicorn.workers.UvicornWorker \


### PR DESCRIPTION
This was removed last week, but still is required.