### PR TITLE
chore(pipeline): run monenfant models

### DIFF
--- a/pipeline/dags/dag_utils/dbt.py
+++ b/pipeline/dags/dag_utils/dbt.py
@@ -98,6 +98,9 @@ def get_before_geocoding_tasks():
                 # FIXME: handle odspep as other sources (add to dags/settings.py)
                 "path:models/staging/sources/odspep",
                 "path:models/intermediate/sources/odspep",
+                # FIXME: handle monenfant as other sources (add to dags/settings.py)
+                "path:models/staging/sources/monenfant",
+                "path:models/intermediate/sources/monenfant",
                 "path:models/intermediate/int__union_adresses.sql",
                 "path:models/intermediate/int__union_services.sql",
                 "path:models/intermediate/int__union_structures.sql",


### PR DESCRIPTION
monenfant extraction is not managed using the sources config anymore. Therefore its dbt models are not picked up automatically.