### PR TITLE
feat(pipeline) : Persister le code INSEE & autres

### DIFF
--- a/pipeline/dags/main.py
+++ b/pipeline/dags/main.py
@@ -42,6 +42,7 @@ def _geocode():
                 _di_surrogate_id,
                 adresse,
                 code_postal,
+                code_insee,
                 commune
             FROM public_intermediate.int__union_adresses;
         """

--- a/pipeline/dbt/models/intermediate/int__union_adresses__enhanced.sql
+++ b/pipeline/dbt/models/intermediate/int__union_adresses__enhanced.sql
@@ -5,7 +5,9 @@ WITH adresses AS (
 valid_adresses AS (
     SELECT adresses.*
     FROM adresses
-    LEFT JOIN LATERAL
+    LEFT JOIN
+        LATERAL
+        -- noqa: disable=references.qualification
         LIST_ADRESSE_ERRORS(
             adresse,
             code_insee,
@@ -17,6 +19,7 @@ valid_adresses AS (
             longitude,
             source
         ) AS errors ON TRUE
+        -- noqa: enable=references.qualification
     WHERE errors.field IS NULL
 ),
 
@@ -24,20 +27,75 @@ geocoded_results AS (
     SELECT * FROM {{ ref('int_extra__geocoded_results') }}
 ),
 
-final AS (
+geocoded_addresses AS (
+
     SELECT
-        {{
-            dbt_utils.star(
-                relation_alias='valid_adresses',
-                from=ref('int__union_adresses'),
-                except=['longitude', 'latitude'])
-        }},
-        geocoded_results.result_score,
-        geocoded_results.result_citycode,
-        COALESCE(valid_adresses.longitude, geocoded_results.longitude) AS "longitude",
-        COALESCE(valid_adresses.latitude, geocoded_results.latitude)   AS "latitude"
+        valid_adresses._di_surrogate_id,
+        valid_adresses.id,
+        valid_adresses.source,
+        valid_adresses.complement_adresse,
+        geocoded_results.result_name     AS adresse,
+        geocoded_results.longitude,
+        geocoded_results.latitude,
+        geocoded_results.result_city     AS commune,
+        geocoded_results.result_postcode AS code_postal,
+        geocoded_results.result_citycode AS code_insee,
+        geocoded_results.result_score
     FROM valid_adresses
     LEFT JOIN geocoded_results ON valid_adresses._di_surrogate_id = geocoded_results._di_surrogate_id
+    WHERE geocoded_results.result_postcode != 'municipality' AND geocoded_results.result_score >= 0.8
+
+),
+
+geocoded_cities AS (
+
+    SELECT
+        valid_adresses._di_surrogate_id,
+        valid_adresses.id,
+        valid_adresses.source,
+        valid_adresses.complement_adresse,
+        valid_adresses.adresse,
+        geocoded_results.longitude,
+        geocoded_results.latitude,
+        geocoded_results.result_city     AS commune,
+        geocoded_results.result_postcode AS code_postal,
+        geocoded_results.result_citycode AS code_insee,
+        geocoded_results.result_score
+    FROM valid_adresses
+    LEFT JOIN geocoded_results ON valid_adresses._di_surrogate_id = geocoded_results._di_surrogate_id
+    WHERE geocoded_results.result_postcode = 'municipality' AND geocoded_results.result_score >= 0.8
+
+),
+
+non_geocoded_addresses AS (
+    SELECT
+        valid_adresses._di_surrogate_id,
+        valid_adresses.id,
+        valid_adresses.source,
+        valid_adresses.complement_adresse,
+        valid_adresses.adresse,
+        CAST(valid_adresses.longitude AS FLOAT)                               AS longitude,
+        CAST(valid_adresses.latitude AS FLOAT)                                AS latitude,
+        valid_adresses.commune,
+        valid_adresses.code_postal,
+        /*
+        If there was a supplied INSEE code, keep it. If not, use the geocoded one,
+        knowing that it might be of poor quality. We need it within the services to
+        establish the diffusion zones.
+        */
+        COALESCE(valid_adresses.code_insee, geocoded_results.result_citycode) AS code_insee,
+        geocoded_results.result_score
+    FROM valid_adresses
+    LEFT JOIN geocoded_results ON valid_adresses._di_surrogate_id = geocoded_results._di_surrogate_id
+    WHERE geocoded_results.result_score IS NULL OR geocoded_results.result_score < 0.8
+),
+
+final AS (
+    SELECT * FROM geocoded_addresses
+    UNION ALL
+    SELECT * FROM geocoded_cities
+    UNION ALL
+    SELECT * FROM non_geocoded_addresses
 )
 
 SELECT * FROM final

--- a/pipeline/dbt/models/intermediate/int__union_services__enhanced.sql
+++ b/pipeline/dbt/models/intermediate/int__union_services__enhanced.sql
@@ -19,13 +19,13 @@ services_with_zone_diffusion AS (
     SELECT
         {{ dbt_utils.star(from=ref('int__union_services'), relation_alias='services', except=["zone_diffusion_code", "zone_diffusion_nom"]) }},
         CASE
-            WHEN services.source = ANY(ARRAY['monenfant', 'soliguide']) THEN adresses.result_citycode
-            WHEN services.source = ANY(ARRAY['reseau-alpha', 'action-logement']) THEN LEFT(adresses.result_citycode, 2)
+            WHEN services.source = ANY(ARRAY['monenfant', 'soliguide']) THEN adresses.code_insee
+            WHEN services.source = ANY(ARRAY['reseau-alpha', 'action-logement']) THEN LEFT(adresses.code_insee, 2)
             ELSE services.zone_diffusion_code
         END AS "zone_diffusion_code",
         CASE
             WHEN services.source = ANY(ARRAY['monenfant', 'soliguide']) THEN adresses.commune
-            WHEN services.source = ANY(ARRAY['reseau-alpha', 'action-logement']) THEN (SELECT departements."LIBELLE" FROM departements WHERE departements."DEP" = LEFT(adresses.result_citycode, 2))
+            WHEN services.source = ANY(ARRAY['reseau-alpha', 'action-logement']) THEN (SELECT departements."LIBELLE" FROM departements WHERE departements."DEP" = LEFT(adresses.code_insee, 2))
             WHEN services.source = 'mediation-numerique' THEN (SELECT departements."LIBELLE" FROM departements WHERE departements."DEP" = services.zone_diffusion_code)
             ELSE services.zone_diffusion_nom
         END AS "zone_diffusion_nom"
@@ -43,7 +43,9 @@ services_with_valid_structure AS (
 valid_services AS (
     SELECT services_with_valid_structure.*
     FROM services_with_valid_structure
-    LEFT JOIN LATERAL
+    LEFT JOIN
+        LATERAL
+        -- noqa: disable=references.qualification
         LIST_SERVICE_ERRORS(
             contact_public,
             contact_nom_prenom,
@@ -79,6 +81,7 @@ valid_services AS (
             zone_diffusion_type,
             pre_requis
         ) AS errors ON TRUE
+        -- noqa: enable=references.qualification
     WHERE errors.field IS NULL
 ),
 
@@ -92,8 +95,7 @@ final AS (
         adresses.adresse            AS "adresse",
         adresses.code_postal        AS "code_postal",
         adresses.code_insee         AS "code_insee",
-        adresses.result_score       AS "_di_geocodage_score",
-        adresses.result_citycode    AS "_di_geocodage_code_insee"
+        adresses.result_score       AS "_di_geocodage_score"
     FROM
         valid_services
     LEFT JOIN adresses ON valid_services._di_adresse_surrogate_id = adresses._di_surrogate_id

--- a/pipeline/dbt/models/intermediate/int__union_structures__enhanced.sql
+++ b/pipeline/dbt/models/intermediate/int__union_structures__enhanced.sql
@@ -13,7 +13,9 @@ adresses AS (
 valid_structures AS (
     SELECT structures.*
     FROM structures
-    LEFT JOIN LATERAL
+    LEFT JOIN
+        LATERAL
+        -- noqa: disable=references.qualification
         LIST_STRUCTURE_ERRORS(
             accessibilite,
             antenne,
@@ -35,6 +37,7 @@ valid_structures AS (
             thematiques,
             typologie
         ) AS errors ON TRUE
+        -- noqa: enable=references.qualification
     WHERE errors.field IS NULL
 ),
 
@@ -49,7 +52,6 @@ final AS (
         adresses.code_postal                                                    AS "code_postal",
         adresses.code_insee                                                     AS "code_insee",
         adresses.result_score                                                   AS "_di_geocodage_score",
-        adresses.result_citycode                                                AS "_di_geocodage_code_insee",
         COALESCE(plausible_personal_emails._di_surrogate_id IS NOT NULL, FALSE) AS "_di_email_is_pii"
     FROM
         valid_structures

--- a/pipeline/dbt/models/intermediate/sources/reseau_alpha/int_reseau_alpha__adresses.sql
+++ b/pipeline/dbt/models/intermediate/sources/reseau_alpha/int_reseau_alpha__adresses.sql
@@ -8,15 +8,15 @@ formations AS (
 
 structure_adresses AS (
     SELECT
-        _di_source_id         AS "source",
-        adresses__longitude   AS "longitude",
-        adresses__latitude    AS "latitude",
-        NULL                  AS "complement_adresse",
-        adresses__ville       AS "commune",
-        content__adresse      AS "adresse",
-        adresses__code_postal AS "code_postal",
-        NULL                  AS "code_insee",
-        'structure--' || id   AS "id"
+        _di_source_id               AS "source",
+        adresses__longitude         AS "longitude",
+        adresses__latitude          AS "latitude",
+        content__complement_adresse AS "complement_adresse",
+        adresses__ville             AS "commune",
+        content__adresse            AS "adresse",
+        adresses__code_postal       AS "code_postal",
+        NULL                        AS "code_insee",
+        'structure--' || id         AS "id"
     FROM structures
 ),
 

--- a/pipeline/dbt/models/intermediate/sources/soliguide/int_soliguide__adresses.sql
+++ b/pipeline/dbt/models/intermediate/sources/soliguide/int_soliguide__adresses.sql
@@ -4,17 +4,18 @@ WITH lieux AS (
 
 final AS (
     SELECT
-        lieu_id                          AS "id",
-        _di_source_id                    AS "source",
-        position__coordinates__x         AS "longitude",
-        position__coordinates__y         AS "latitude",
-        position__additional_information AS "complement_adresse",
-        position__city                   AS "commune",
-        position__address                AS "adresse",
-        position__postal_code            AS "code_postal",
+        lieu_id                                                  AS "id",
+        _di_source_id                                            AS "source",
+        position__coordinates__x                                 AS "longitude",
+        position__coordinates__y                                 AS "latitude",
+        position__additional_information                         AS "complement_adresse",
+        position__city                                           AS "commune",
+        REGEXP_REPLACE(position__address, ', \d\d\d\d\d.*$', '') AS "adresse",
+        position__postal_code                                    AS "code_postal",
         -- TODO: use position__city_code
         -- currently the field contains a majority of postal codes...
-        NULL                             AS "code_insee"
+        -- update(2024-08-07) : this is still the case.
+        NULL                                                     AS "code_insee"
     FROM lieux
     ORDER BY 1
 )

--- a/pipeline/dbt/models/marts/inclusion/_inclusion_models.yml
+++ b/pipeline/dbt/models/marts/inclusion/_inclusion_models.yml
@@ -10,11 +10,6 @@ models:
         data_type: text
         constraints:
           - type: primary_key
-      - name: _di_geocodage_code_insee
-        data_type: text
-        constraints:
-          - type: check
-            expression: '(CHECK_CODE_INSEE(_di_geocodage_code_insee))'
       - name: _di_geocodage_score
         data_type: float
       - name: id
@@ -140,11 +135,6 @@ models:
           - type: not_null
           - type: foreign_key
             expression: "public_marts.marts_inclusion__structures (_di_surrogate_id)"
-      - name: _di_geocodage_code_insee
-        data_type: text
-        constraints:
-          - type: check
-            expression: '(CHECK_CODE_INSEE(_di_geocodage_code_insee))'
       - name: _di_geocodage_score
         data_type: float
       - name: id

--- a/pipeline/dbt/models/staging/sources/cd72/stg_cd72__services.sql
+++ b/pipeline/dbt/models/staging/sources/cd72/stg_cd72__services.sql
@@ -14,7 +14,7 @@ final AS (
         data ->> 'lieu'                                                                              AS "lieu",
         data ->> 'siret'                                                                             AS "siret",
         -- TODO: frais, change column type from bool to ref list on grist
-        data ->> 'adresse'                                                                           AS "adresse",
+        SPLIT_PART(data ->> 'adresse', E'\n', 1))                                                    AS "adresse",
         data ->> 'commune'                                                                           AS "commune",
         (SELECT ARRAY_AGG(TRIM(p)) FROM UNNEST(STRING_TO_ARRAY(data ->> 'profils', ',')) AS "p")     AS "profils",
         data ->> 'courriel'                                                                          AS "courriel",

--- a/pipeline/dbt/models/staging/sources/cd72/stg_cd72__structures.sql
+++ b/pipeline/dbt/models/staging/sources/cd72/stg_cd72__structures.sql
@@ -4,20 +4,20 @@ WITH source AS (
 
 final AS (
     SELECT
-        _di_source_id                     AS "_di_source_id",
-        data ->> 'id'                     AS "id",
-        data ->> 'nom'                    AS "nom",
-        data ->> 'siret'                  AS "siret",
-        data ->> 'adresse'                AS "adresse",
-        data ->> 'commune'                AS "commune",
-        data ->> 'courriel'               AS "courriel",
-        CAST(data ->> 'date_maj' AS DATE) AS "date_maj",
-        data ->> 'site_web'               AS "site_web",
-        data ->> 'telephone'              AS "telephone",
-        data ->> 'typologie'              AS "typologie",
-        data ->> 'code_postal'            AS "code_postal",
-        data ->> 'horaires_ouverture'     AS "horaires_ouverture",
-        data ->> 'presentation_detail'    AS "presentation_detail"
+        _di_source_id                                  AS "_di_source_id",
+        data ->> 'id'                                  AS "id",
+        data ->> 'nom'                                 AS "nom",
+        data ->> 'siret'                               AS "siret",
+        TRIM(SPLIT_PART(data ->> 'adresse', E'\n', 1)) AS "adresse",
+        data ->> 'commune'                             AS "commune",
+        data ->> 'courriel'                            AS "courriel",
+        CAST(data ->> 'date_maj' AS DATE)              AS "date_maj",
+        data ->> 'site_web'                            AS "site_web",
+        data ->> 'telephone'                           AS "telephone",
+        data ->> 'typologie'                           AS "typologie",
+        data ->> 'code_postal'                         AS "code_postal",
+        data ->> 'horaires_ouverture'                  AS "horaires_ouverture",
+        data ->> 'presentation_detail'                 AS "presentation_detail"
     FROM source
 )
 

--- a/pipeline/dbt/models/staging/sources/reseau_alpha/stg_reseau_alpha__structures.sql
+++ b/pipeline/dbt/models/staging/sources/reseau_alpha/stg_reseau_alpha__structures.sql
@@ -13,7 +13,7 @@ adresses AS (
         TRIM(SUBSTRING(source.data ->> 'content__adresse' FROM '^(.+)\s\d{5} - .+$')) AS "content__adresse"
     FROM
         source,
-        LATERAL(SELECT * FROM JSONB_PATH_QUERY(source.data, '$.adresses[*]')) AS adresses (data)
+        LATERAL (SELECT * FROM JSONB_PATH_QUERY(source.data, '$.adresses[*]')) AS adresses (data)
     WHERE
         -- a minority of structures have more than one addresses, which is not managed by
         -- the data·inclusion schema. Skip these addresses.
@@ -22,26 +22,27 @@ adresses AS (
 
 final AS (
     SELECT
-        source._di_source_id                                                                                 AS "_di_source_id",
-        adresses.adresses__ville                                                                             AS "adresses__ville",
-        adresses.adresses__latitude                                                                          AS "adresses__latitude",
-        adresses.adresses__longitude                                                                         AS "adresses__longitude",
-        adresses.adresses__code_postal                                                                       AS "adresses__code_postal",
-        adresses.content__adresse                                                                            AS "content__adresse",
-        CAST(ARRAY(SELECT * FROM JSONB_ARRAY_ELEMENTS_TEXT(source.data -> 'activitesFormation')) AS TEXT []) AS "activites_formation",
-        source.data ->> 'id'                                                                                 AS "id",
-        source.data ->> 'nom'                                                                                AS "nom",
-        source.data ->> 'url'                                                                                AS "url",
-        source.data ->> 'logo'                                                                               AS "logo",
-        source.data ->> 'type'                                                                               AS "type",
-        source.data ->> 'description'                                                                        AS "description",
+        source._di_source_id                                                                                   AS "_di_source_id",
+        adresses.adresses__ville                                                                               AS "adresses__ville",
+        adresses.adresses__latitude                                                                            AS "adresses__latitude",
+        adresses.adresses__longitude                                                                           AS "adresses__longitude",
+        adresses.adresses__code_postal                                                                         AS "adresses__code_postal",
+        COALESCE(NULLIF(TRIM(SPLIT_PART(adresses.content__adresse, E'\n', 2)), ''), adresses.content__adresse) AS "content__adresse",
+        NULLIF(TRIM(SPLIT_PART(adresses.content__adresse, E'\n', 3)), '')                                      AS "content__complement_adresse",
+        CAST(ARRAY(SELECT * FROM JSONB_ARRAY_ELEMENTS_TEXT(source.data -> 'activitesFormation')) AS TEXT [])   AS "activites_formation",
+        source.data ->> 'id'                                                                                   AS "id",
+        source.data ->> 'nom'                                                                                  AS "nom",
+        source.data ->> 'url'                                                                                  AS "url",
+        source.data ->> 'logo'                                                                                 AS "logo",
+        source.data ->> 'type'                                                                                 AS "type",
+        source.data ->> 'description'                                                                          AS "description",
         TO_DATE(
             SUBSTRING(source.data ->> 'content__date_maj' FROM 'Date de la dernière modification : (.*)'),
             'DD TMmonth YYYY'
-        )                                                                                                    AS "content__date_maj",
-        TRIM(source.data ->> 'content__telephone')                                                           AS "content__telephone",
-        TRIM(source.data ->> 'content__courriel')                                                            AS "content__courriel",
-        TRIM(source.data ->> 'content__site_web')                                                            AS "content__site_web"
+        )                                                                                                      AS "content__date_maj",
+        TRIM(source.data ->> 'content__telephone')                                                             AS "content__telephone",
+        TRIM(source.data ->> 'content__courriel')                                                              AS "content__courriel",
+        TRIM(source.data ->> 'content__site_web')                                                              AS "content__site_web"
     FROM source
     LEFT JOIN adresses ON source.data ->> 'id' = adresses.structure_id
 )

--- a/pipeline/tests/integration/test_geocoding.py
+++ b/pipeline/tests/integration/test_geocoding.py
@@ -24,6 +24,7 @@ def sample_df() -> pd.DataFrame:
                 "_di_surrogate_id": "1",
                 "adresse": "17 rue Malus",
                 "code_postal": "59000",
+                "code_insee": "59350",
                 "commune": "Lille",
             },
             {
@@ -31,6 +32,7 @@ def sample_df() -> pd.DataFrame:
                 "_di_surrogate_id": "2",
                 "adresse": None,
                 "code_postal": None,
+                "code_insee": None,
                 "commune": None,
             },
         ]
@@ -46,6 +48,7 @@ def test_ban_geocode(
             "_di_surrogate_id": "1",
             "source": "dora",
             "adresse": "17 rue Malus",
+            "code_insee": "59350",
             "code_postal": "59000",
             "commune": "Lille",
             "latitude": "50.627078",


### PR DESCRIPTION
Lorsque le code INSEE est supérieur à 0.8 (pour l'instant...) on se propose d'enregistrer dans les marts les valeurs retournées par la BAN car plus "propres" et canoniques.

Dans les autres cas, on conserve les données d'origine (en notant le score). 

Pour les "villes" (résultats de type "municipality") on conserve l'adresse d'origine (vide la plupart du temps, mais pas toujours) et on persiste le code INSEE, code postal et nom de la commune venant de la BAN.

On a pu constater un léger souci avec les adresses Soliguide, corrigé pour augmenter les scores désormais. Pasd'autre amélioration "évidente" en vue a priori.
- siao a pas mal de retours à la ligne, de codes postaux et de communes dans ses lignes d'adresse
- soliguide a des echanges entre commune, adresse, complement... exemples:

```
-[ RECORD 31 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | 29510 Briec
complement_adresse | 
-[ RECORD 32 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | 44300 Nantes
complement_adresse | Quartier Doulon - Bottière
-[ RECORD 33 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | 68100 Mulhouse
complement_adresse | Tournée dans Mulhouse centre : parking Leclerc, gare, centre-ville, place de la bourse
-[ RECORD 34 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | Parc d'Activités Économiques du Sègre
complement_adresse | 
-[ RECORD 35 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | 67000 Strasbourg
complement_adresse | 
-[ RECORD 36 ]-----+---------------------------------------------------------------------------------------------------------------------------------------------------------
adresse            | 85 Rue Lunaret
complement_adresse | 
```
Sur ~134000 adresses, ~91000 ont un score au-dessus de 0.8, et ~121000 au-dessus de 0.6.

