### PR TITLE
chore(deployment) : Reduce the allowed time for images to stay

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -254,8 +254,8 @@ resource "null_resource" "up" {
 
   provisioner "remote-exec" {
     inline = [
-      "docker image prune --all --force --filter 'until=168h'",
-      "docker container prune --force --filter 'until=168h'",
+      "docker image prune --all --force --filter 'until=48h'",
+      "docker container prune --force --filter 'until=48h'",
       "cd ${local.work_dir}",
       "docker compose --progress=plain up --pull=always --force-recreate --remove-orphans --wait --wait-timeout 1200 --quiet-pull --detach",
       # FIXME: ideally this file should be removed


### PR DESCRIPTION
We frequently encounter disk space issues.

Last I checked, a ton of images were sitting aroung since 5/6 days.

OI don't think we need that much cache time and it seems we don't reuse much of the layers anyway (this could be another investigation, but... longer)

Since every image is always pushed and downloaded almost entirely again, there is little argument that we can just wipe the old ones more frequently.