### PR TITLE
chore(deployment) : Fix sources object access

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -105,6 +105,21 @@ resource "scaleway_object_bucket_policy" "main" {
         },
         {
           Effect = "Allow",
+          Sid    = "Grant list & read in sources/* to airflow",
+          Principal = {
+            SCW = ["application_id:${var.airflow_application_id}"]
+          },
+          Action = [
+            "s3:ListBucket",
+            "s3:GetObject"
+          ],
+          Resource = [
+            "${scaleway_object_bucket.main.name}",
+            "${scaleway_object_bucket.main.name}/sources/*",
+          ]
+        },
+        {
+          Effect = "Allow",
           Sid    = "Grant list & read in data/marts/* to the api",
           Principal = {
             SCW = ["application_id:${var.api_scw_application_id}"]


### PR DESCRIPTION
It seems reasonable that the Airflow DAGs would access the sources folder and can get object properties in it.

In staging:
```
[2024-08-12T16:08:33.544+0000] {process_utils.py:191} INFO -   File "/opt/airflow/venvs/python/venv/lib/python3.12/site-packages/botocore/client.py", line 1021, in _make_api_call                                  
[2024-08-12T16:08:33.545+0000] {process_utils.py:191} INFO -     raise error_class(parsed_response, operation_name)
[2024-08-12T16:08:33.546+0000] {process_utils.py:191} INFO - botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden                                                 
```