### PR TITLE
fix(pipeline): bridge tables depend on main tables

### DIFF
--- a/pipeline/dbt/macros/marts_inclusion__unnest_jsonb_list_to_table.sql
+++ b/pipeline/dbt/macros/marts_inclusion__unnest_jsonb_list_to_table.sql
@@ -1,7 +1,7 @@
 {% macro unnest_jsonb_list_to_table(resource_type, nested_column) %}
 
 WITH {{ resource_type }}s AS (
-    SELECT * FROM {{ ref('int__union_{}s__enhanced'.format(resource_type) ) }}
+    SELECT * FROM {{ ref('marts_inclusion__{}s'.format(resource_type) ) }}
 ),
 
 final AS (


### PR DESCRIPTION
Currently, the bridge tables are updated concurrently to the main tables. This can make bridge & main tables inconsistent and hence dbt contracts on fk fail.