### PR TITLE
chore(pipeline) : Corriger l'intégration des contacts Brevo

### DIFF
--- a/pipeline/dags/import_brevo.py
+++ b/pipeline/dags/import_brevo.py
@@ -76,10 +76,24 @@ with airflow.DAG(
         op_kwargs={"stream_id": STREAM_ID, "source_id": SOURCE_ID},
     )
 
-    dbt_build_brevo = dbt_operator_factory(
+    dbt_build_brevo_tmp = dbt_operator_factory(
         task_id="dbt_build_brevo",
         command="build",
         select="path:models/staging/brevo path:models/intermediate/brevo",
+        dbt_vars={"build_intermediate_tmp": True},
     )
 
-    (start >> extract_rgpd_contacts >> load_rgpd_contacts >> dbt_build_brevo >> end)
+    dbt_run_brevo = dbt_operator_factory(
+        task_id="dbt_run_brevo",
+        command="run",
+        select="path:models/staging/brevo path:models/intermediate/brevo",
+    )
+
+    (
+        start
+        >> extract_rgpd_contacts
+        >> load_rgpd_contacts
+        >> dbt_build_brevo_tmp
+        >> dbt_run_brevo
+        >> end
+    )

--- a/pipeline/dbt/models/intermediate/brevo/_brevo__models.yml
+++ b/pipeline/dbt/models/intermediate/brevo/_brevo__models.yml
@@ -4,6 +4,7 @@ models:
   - name: int_brevo__contacts
     columns:
       - name: id
+        description: L'ID interne Brevo de ce "contact". Largement inutilisé mais sert de clé primaire.
         data_tests:
           - unique
           - not_null
@@ -14,7 +15,16 @@ models:
           - dbt_utils.not_constant
           - dbt_utils.not_empty_string
       - name: est_interdit
+        description: |
+          Signifie que cet e-mail est considéré par Brevo comme:
+          - un "hard bounce" (n'existe pas)
+          - a fait l'objet d'une demande de désincription explicite.
+          - a classé le mail en spam
+          - a été classé "bloqué" par un administrateur Brevo
         data_tests:
           - not_null
           - accepted_values:
               values: [true, false]
+
+      - name: date_di_rgpd_opposition
+        description: Date d'opposition au RGPD telle qu'entrée par notre DPO dans Brevo lorsque signalé.

--- a/pipeline/dbt/models/intermediate/sources/dora/int_dora__services.sql
+++ b/pipeline/dbt/models/intermediate/sources/dora/int_dora__services.sql
@@ -15,7 +15,9 @@ di_profil_by_dora_profil AS (
 ),
 
 blocked_contacts AS (
-    SELECT DISTINCT UNNEST(contact_uids) AS id FROM {{ ref('int_brevo__contacts') }} WHERE est_interdit = TRUE OR date_di_rgpd_opposition IS NOT NULL
+    SELECT DISTINCT UNNEST(contact_uids) AS id
+    FROM {{ ref('int_brevo__contacts') }}
+    WHERE est_interdit = TRUE OR date_di_rgpd_opposition IS NOT NULL
 ),
 
 blocked_contact_uids AS (
@@ -23,6 +25,7 @@ blocked_contact_uids AS (
         SPLIT_PART(id, ':', 3) AS id,
         SPLIT_PART(id, ':', 2) AS kind
     FROM blocked_contacts
+    WHERE SPLIT_PART(id, ':', 1) = 'dora'
 ),
 
 blocked_services_uids AS (


### PR DESCRIPTION
Dora ne peut pas construire son étape intermédaire car cette source s'attend à la présence d'une table prevo dans `public_intermediate_tmp` désormais ^^ 

Il faut donc construire les tables Brevo comme les tables sources : dans tmp d'abord, puis testé, puis lancé.