### PR TITLE
chore(dev) : Do not restart docker images in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ x-airflow-common:
 services:
   airflow-db:
     image: postgres:14
-    restart: on-failure
+    restart: no
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "airflow" ]
       interval: 5s
@@ -68,7 +68,7 @@ services:
     <<: *airflow-common
     image: data-inclusion/pipeline
     command: webserver
-    restart: on-failure
+    restart: no
     ports:
       - ${AIRFLOW_UI_PORT:-8080}:8080
     depends_on:
@@ -82,7 +82,7 @@ services:
     build:
       context: pipeline
     command: scheduler
-    restart: on-failure
+    restart: no
     healthcheck:
       test:
         [
@@ -114,7 +114,7 @@ services:
   minio:
     image: minio/minio:RELEASE.2024-05-10T01-41-38Z
     command: server /data
-    restart: on-failure
+    restart: no
     ports:
       - 9000:9000
       - 9001:9001
@@ -139,7 +139,7 @@ services:
   target-db:
     image: data-inclusion/datawarehouse
     build: datawarehouse
-    restart: on-failure
+    restart: no
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off -c log_statement=all
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "data-inclusion" ]
@@ -160,7 +160,7 @@ services:
     depends_on:
       target-db:
         condition: service_healthy
-    restart: on-failure
+    restart: no
     ports:
       - ${API_PORT:-8000}:8000
     environment:


### PR DESCRIPTION
The 'on-failure' setting makes the images restart almost all the time, especially upon reboot, if I work on this project or not.

This is good in a production setting, but in development, restarting after a reboot on my personal computer drains my battery for no good reason.

Furthermore, if there was an actual issue with the containers in development, they should  just stop and the developer should fix the issue, not run into a mindless loop till oblivion.