### PR TITLE
fix(pipeline) : Fix soliguide,monenfant zone_diffusion issue

### DIFF
--- a/pipeline/dbt/models/intermediate/int__union_services__enhanced.sql
+++ b/pipeline/dbt/models/intermediate/int__union_services__enhanced.sql
@@ -42,7 +42,7 @@ zones_diffusion AS (
         CASE
             WHEN NOT (services.source = ANY(ARRAY['monenfant', 'action-logement', 'soliguide', 'reseau-alpha', 'mediation-numerique']))
                 THEN services.zone_diffusion_code
-            WHEN services.zone_diffusion_type = 'communes' AND adresses.code_insee IS NOT NULL
+            WHEN services.zone_diffusion_type = 'commune' AND adresses.code_insee IS NOT NULL
                 THEN adresses.code_insee
             WHEN services.zone_diffusion_type = 'departement' AND adresses.code_departement IS NOT NULL
                 THEN adresses.code_departement
@@ -51,7 +51,7 @@ zones_diffusion AS (
         CASE
             WHEN NOT (services.source = ANY(ARRAY['monenfant', 'action-logement', 'soliguide', 'reseau-alpha', 'mediation-numerique']))
                 THEN services.zone_diffusion_nom
-            WHEN services.zone_diffusion_type = 'communes' AND adresses.commune IS NOT NULL
+            WHEN services.zone_diffusion_type = 'commune' AND adresses.commune IS NOT NULL
                 THEN adresses.commune
             WHEN services.zone_diffusion_type = 'departement' AND departements.nom IS NOT NULL
                 THEN departements.nom


### PR DESCRIPTION
When the zone_diffusion_code is not filled, the services are not returned.

Following a fix about those zones in
b0c11dddcea7569e6a2acb27249e9a0ee035b703, there was a tiny mistake (an extra 's') that made 50_000 services become undiscoverable.

Since that can become a huge issue, let's enforce better data testing in the pipeline to ensure it does not arise again.