### PR TITLE
feat(pipeline) : Simplify notify_rgpd_contacts

### DIFF
--- a/pipeline/dbt/models/intermediate/_models.yml
+++ b/pipeline/dbt/models/intermediate/_models.yml
@@ -11,10 +11,6 @@ models:
 
   - name: int__union_contacts
     columns:
-      - name: contact_uid
-        data_tests:
-          - unique
-          - not_null
       - name: courriel
         data_tests:
           - not_null
@@ -260,23 +256,22 @@ unit_tests:
     given:
       - input: ref('int__union_contacts')
         rows:
-          - {"source": "dora", "id": "foo", "courriel": "truc@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
-          - {"source": "mednum", "id": "bar", "courriel": "truc@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
-          - {"source": "lezemplois", "id": "baz", "courriel": "truc@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
+          - {"source": "dora", "id": "foo", "courriel": "truc1@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
+          - {"source": "other", "id": "foo", "courriel": "truc1@toto.at", "contact_nom_prenom": "Jean Other", "telephone": "9876543210"}
+          - {"source": "mednum", "id": "bar", "courriel": "truc2@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
+          - {"source": "lezemplois", "id": "baz", "courriel": "truc3@toto.at", "contact_nom_prenom": "Jean Valjean", "telephone": "0123456789"}
           - {"source": "autre", "id": "solo", "courriel": "solo@autre.net", "contact_nom_prenom": "Autre Personne", "telephone": "06666666"}
       - input: ref('int_brevo__contacts')
-        format: sql
         rows:
-          select ARRAY['dora:services:foo'] as contact_uids, TRUE as est_interdit, '2021-01-01' as date_di_rgpd_opposition
-          UNION ALL
-          select ARRAY['mednum:services:bar'] as contact_uids, FALSE as est_interdit, '2021-01-01' as date_di_rgpd_opposition
-          UNION ALL
-          select ARRAY['lezemplois:services:baz'] as contact_uids, FALSE as est_interdit, NULL as date_di_rgpd_opposition
-          UNION ALL
-          select ARRAY['sans:services:rapport'] as contact_uids, TRUE as est_interdit, NULL as date_di_rgpd_opposition
+          # note: values can't be NULL. has_hardbounced is set to true/false by brevo, and was_objected to is set to true/false by us.
+          - {"courriel": "truc1@toto.at", "has_hardbounced": true, "was_objected_to": true}
+          - {"courriel": "truc2@toto.at", "has_hardbounced": false, "was_objected_to": true}
+          - {"courriel": "truc3@toto.at", "has_hardbounced": false, "was_objected_to": false}
+          - {"courriel": "solo@autre.net", "has_hardbounced": true, "was_objected_to": false}
     expect:
       rows:
         - {source: dora, id: foo, courriel: NULL, contact_nom_prenom: NULL, telephone: NULL}  # objected to, hardbounce
+        - {source: other, id: foo, courriel: NULL, contact_nom_prenom: NULL, telephone: NULL}  # objected to, hardbounce
         - {source: mednum, id: bar, courriel: NULL, contact_nom_prenom: NULL, telephone: NULL}  # objected to, no hardbounce
-        - {source: lezemplois, id: baz, courriel: truc@toto.at, contact_nom_prenom: Jean Valjean, telephone: '0123456789'} # not objected to, no hardbounce
-        - {source: autre, id: solo, courriel: solo@autre.net, contact_nom_prenom: Autre Personne, telephone: '06666666'} # hardbounce : only email is hidden
+        - {source: lezemplois, id: baz, courriel: truc3@toto.at, contact_nom_prenom: Jean Valjean, telephone: '0123456789'} # not objected to, no hardbounce
+        - {source: autre, id: solo, courriel: NULL, contact_nom_prenom: Autre Personne, telephone: '06666666'} # hardbounce : only email is hidden

--- a/pipeline/dbt/models/intermediate/brevo/_brevo__models.yml
+++ b/pipeline/dbt/models/intermediate/brevo/_brevo__models.yml
@@ -14,7 +14,7 @@ models:
           - not_null
           - dbt_utils.not_constant
           - dbt_utils.not_empty_string
-      - name: est_interdit
+      - name: has_hardbounced
         description: |
           Signifie que cet e-mail est considéré par Brevo comme:
           - un "hard bounce" (n'existe pas)
@@ -22,9 +22,12 @@ models:
           - a classé le mail en spam
           - a été classé "bloqué" par un administrateur Brevo
         data_tests:
-          - not_null
           - accepted_values:
               values: [true, false]
 
-      - name: date_di_rgpd_opposition
-        description: Date d'opposition au RGPD telle qu'entrée par notre DPO dans Brevo lorsque signalé.
+      - name: was_objected_to
+        description: |
+          Permet de savoir si le contact a fait l'objet d'une demande de retrait RGPD.
+        data_tests:
+          - accepted_values:
+              values: [true, false]

--- a/pipeline/dbt/models/intermediate/brevo/int_brevo__contacts.sql
+++ b/pipeline/dbt/models/intermediate/brevo/int_brevo__contacts.sql
@@ -4,11 +4,10 @@ WITH contacts AS (
 
 final AS (
     SELECT
-        id                                 AS "id",
-        email                              AS "courriel",
-        email_blacklisted                  AS "est_interdit",
-        date_di_rgpd_opposition            AS "date_di_rgpd_opposition",
-        STRING_TO_ARRAY(contact_uids, ',') AS "contact_uids"
+        id                                  AS "id",
+        email                               AS "courriel",
+        email_blacklisted                   AS "has_hardbounced",
+        date_di_rgpd_opposition IS NOT NULL AS "was_objected_to"
     FROM contacts
 )
 

--- a/pipeline/dbt/models/intermediate/int__union_contacts.sql
+++ b/pipeline/dbt/models/intermediate/int__union_contacts.sql
@@ -18,8 +18,7 @@ final AS (
         source              AS "source",
         courriel            AS "courriel",
         telephone           AS "telephone",
-        contact_nom_prenom  AS "contact_nom_prenom",
-        contact_uid         AS "contact_uid"
+        contact_nom_prenom  AS "contact_nom_prenom"
     FROM contacts_union
 )
 

--- a/pipeline/dbt/models/intermediate/sources/dora/_dora__models.yml
+++ b/pipeline/dbt/models/intermediate/sources/dora/_dora__models.yml
@@ -14,10 +14,6 @@ models:
 
   - name: int_dora__contacts
     columns:
-      - name: contact_uid
-        data_tests:
-          - unique
-          - not_null
       - name: courriel
         data_tests:
           - not_null

--- a/pipeline/dbt/models/intermediate/sources/dora/int_dora__contacts.sql
+++ b/pipeline/dbt/models/intermediate/sources/dora/int_dora__contacts.sql
@@ -4,8 +4,7 @@ WITH structure_contacts AS (
         _di_source_id            AS "source",
         courriel                 AS "courriel",
         telephone                AS "telephone",
-        NULL                     AS "contact_nom_prenom",
-        'dora:structures:' || id AS "contact_uid"
+        NULL                     AS "contact_nom_prenom"
     FROM {{ ref('stg_dora__structures') }}
     WHERE courriel IS NOT NULL
 ),
@@ -16,8 +15,7 @@ service_contacts AS (
         _di_source_id          AS "source",
         courriel               AS "courriel",
         telephone              AS "telephone",
-        contact_nom_prenom     AS "contact_nom_prenom",
-        'dora:services:' || id AS "contact_uid"
+        contact_nom_prenom     AS "contact_nom_prenom"
     FROM {{ ref('stg_dora__services') }}
     WHERE courriel IS NOT NULL
 ),

--- a/pipeline/dbt/models/intermediate/sources/mediation_numerique/_mediation_numerique_models.yml
+++ b/pipeline/dbt/models/intermediate/sources/mediation_numerique/_mediation_numerique_models.yml
@@ -18,10 +18,6 @@ models:
 
   - name: int_mediation_numerique__contacts
     columns:
-      - name: contact_uid
-        data_tests:
-          - unique
-          - not_null
       - name: courriel
         data_tests:
           - not_null

--- a/pipeline/dbt/models/intermediate/sources/mediation_numerique/int_mediation_numerique__contacts.sql
+++ b/pipeline/dbt/models/intermediate/sources/mediation_numerique/int_mediation_numerique__contacts.sql
@@ -4,9 +4,7 @@ WITH final AS (
         _di_source_id                           AS "source",
         courriel                                AS "courriel",
         telephone                               AS "telephone",
-        NULL                                    AS "contact_nom_prenom",
-        -- services in mediation numerique have no contact information
-        'mediation-numerique:structures:' || id AS "contact_uid"
+        NULL                                    AS "contact_nom_prenom"
     FROM {{ ref('stg_mediation_numerique__structures') }}
     WHERE courriel IS NOT NULL
 )

--- a/pipeline/dbt/models/intermediate/sources/mes_aides/_mes_aides__models.yml
+++ b/pipeline/dbt/models/intermediate/sources/mes_aides/_mes_aides__models.yml
@@ -12,7 +12,6 @@ models:
           - unique
           - not_null
           - dbt_utils.not_empty_string
-
   - name: int_mes_aides__structures
     data_tests:
       - check_structure:
@@ -56,10 +55,6 @@ models:
               field: id
   - name: int_mes_aides__contacts
     columns:
-      - name: contact_uid
-        data_tests:
-          - unique
-          - not_null
       - name: courriel
         data_tests:
           - not_null

--- a/pipeline/dbt/models/intermediate/sources/mes_aides/int_mes_aides__contacts.sql
+++ b/pipeline/dbt/models/intermediate/sources/mes_aides/int_mes_aides__contacts.sql
@@ -1,15 +1,21 @@
 WITH structure_contacts AS (
     SELECT
-        email                      AS "courriel",
-        'mes-aides:garages:' || id AS contact_uid
+        id            AS "id",
+        _di_source_id AS "source",
+        email         AS "courriel",
+        telephone     AS "telephone",
+        NULL          AS "contact_nom_prenom"
     FROM {{ ref('stg_mes_aides__garages') }}
     WHERE email IS NOT NULL
 ),
 
 service_contacts AS (
     SELECT
-        contact_email            AS "courriel",
-        'mes-aides:aides:' || id AS contact_uid
+        id            AS "id",
+        _di_source_id AS "source",
+        contact_email AS "courriel",
+        NULL          AS "telephone",
+        NULL          AS "contact_nom_prenom"
     FROM {{ ref('stg_mes_aides__permis_velo') }}
     WHERE contact_email IS NOT NULL
 ),

--- a/pipeline/dbt/models/staging/brevo/_brevo__models.yml
+++ b/pipeline/dbt/models/staging/brevo/_brevo__models.yml
@@ -31,8 +31,3 @@ models:
         data_tests:
           - not_null
           - dbt_utils.not_constant
-      - name: contact_uids
-        data_tests:
-          - not_null
-          - dbt_utils.not_empty_string
-          - dbt_utils.not_constant

--- a/pipeline/dbt/models/staging/brevo/stg_brevo__contacts.sql
+++ b/pipeline/dbt/models/staging/brevo/stg_brevo__contacts.sql
@@ -11,7 +11,6 @@ final AS (
         CAST(ARRAY(SELECT * FROM JSONB_ARRAY_ELEMENTS(data -> 'listIds')) AS INT []) AS "list_ids",
         data ->> 'id'                                                                AS "id",
         TO_DATE(data -> 'attributes' ->> 'DATE_DI_RGPD_OPPOSITION', 'YYYY-MM-DD')    AS "date_di_rgpd_opposition",
-        data -> 'attributes' ->> 'CONTACT_UIDS'                                      AS "contact_uids",
         NULLIF(TRIM(data ->> 'email'), '')                                           AS "email"
     FROM source
 )


### PR DESCRIPTION
After an entire year of operation, we noticed that our sources never change their contact emails. Ever.

Even if someday this happens, we can probably suppose that it's till going to be quite rare.

In those exceptional cases, it means that the structure would get a new RGPD notification.

But it does make the code way easier to maintain and more robust:
- now we will never miss an email that would have been "forgotten" by Brevo (due to rate limits, payment issues, ...)
- it can also be seen as a feature to send a new notification if the email changes, for instance when the previous one was incorrect.

Moreover, we don't need to maintain the `contact_uid` list that was sent to brevo.