### PR TITLE
chore(api):remove sources filter on structures

### DIFF
--- a/api/src/data_inclusion/api/inclusion_data/routes.py
+++ b/api/src/data_inclusion/api/inclusion_data/routes.py
@@ -151,10 +151,6 @@ def list_sources_endpoint(
 def list_services_endpoint(
     request: fastapi.Request,
     db_session=fastapi.Depends(db.get_session),
-    source: Annotated[
-        Optional[str],
-        fastapi.Query(include_in_schema=False),
-    ] = None,
     sources: Annotated[
         Optional[list[str]],
         fastapi.Query(
@@ -236,9 +232,6 @@ def list_services_endpoint(
 
     if thematiques is None and thematique is not None:
         thematiques = [thematique]
-
-    if sources is None and source is not None:
-        sources = [source]
 
     if code_departement is None and departement is not None:
         code_departement = departement

--- a/api/src/data_inclusion/api/inclusion_data/routes.py
+++ b/api/src/data_inclusion/api/inclusion_data/routes.py
@@ -54,10 +54,6 @@ CodeRegionFilter = Annotated[
 )
 def list_structures_endpoint(
     request: fastapi.Request,
-    source: Annotated[
-        Optional[str],
-        fastapi.Query(include_in_schema=False),
-    ] = None,
     sources: Annotated[
         Optional[list[str]],
         fastapi.Query(
@@ -94,9 +90,6 @@ def list_structures_endpoint(
     code_commune: CodeCommuneFilter = None,
     db_session=fastapi.Depends(db.get_session),
 ):
-    if sources is None and source is not None:
-        sources = [source]
-
     region = get_region_by_code_or_slug(code=code_region, slug=slug_region)
 
     if code_departement is None and departement is not None:

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -50,7 +50,7 @@ def test_list_structures_all(api_client):
     assert resp_data == {
         "items": [
             {
-                "accessibilite": "https://acceslibre.beta.gouv.fr/app/kitchen-amount/",
+                "accessibilite": "https://acceslibre.beta.gouv.fr/app/nom-asseoir/",
                 "adresse": "49, avenue de Pichon",
                 "antenne": False,
                 "code_insee": "59350",
@@ -60,11 +60,11 @@ def test_list_structures_all(api_client):
                 "courriel": "levyalexandre@example.org",
                 "date_maj": "2023-01-01",
                 "horaires_ouverture": 'Mo-Fr 10:00-20:00 "sur rendez-vous"; PH off',
-                "id": "kitchen-amount",
+                "id": "nom-asseoir",
                 "labels_autres": ["Nièvre médiation numérique"],
                 "labels_nationaux": [],
                 "latitude": -20.074628,
-                "lien_source": "https://dora.fr/kitchen-amount",
+                "lien_source": "https://dora.fr/nom-asseoir",
                 "longitude": 99.899603,
                 "nom": "Perrin",
                 "presentation_detail": "Or personne jambe.",
@@ -177,23 +177,6 @@ def test_list_structures_filter_by_label(
 
 
 @pytest.mark.with_token
-@pytest.mark.feature_deprecated
-def test_list_structures_filter_by_source(api_client):
-    structure_1 = factories.StructureFactory(source="emplois-de-linclusion")
-    factories.StructureFactory(source="dora")
-
-    url = "/api/v0/structures/"
-    response = api_client.get(url, params={"source": "emplois-de-linclusion"})
-
-    resp_data = response.json()
-    assert_paginated_response_data(response.json(), total=1)
-    assert_structure_data(structure_1, resp_data["items"][0])
-
-    response = api_client.get(url, params={"source": "soliguide"})
-    assert_paginated_response_data(response.json(), total=0)
-
-
-@pytest.mark.with_token
 def test_list_sources(api_client):
     url = "/api/v0/sources/"
     response = api_client.get(url)
@@ -216,25 +199,6 @@ def test_list_sources(api_client):
             "data-inclusion",
         ]
     )
-
-
-@pytest.mark.with_token
-@pytest.mark.feature_deprecated
-def test_list_structures_filter_by_source_and_id(
-    api_client,
-):
-    factories.StructureFactory(source="emplois-de-linclusion", id="foo")
-    structure_2 = factories.StructureFactory(source="dora", id="foo")
-    factories.StructureFactory(source="dora", id="bar")
-
-    url = "/api/v0/structures/"
-
-    response = api_client.get(url, params={"source": "dora", "id": "foo"})
-    resp_data = response.json()
-
-    resp_data = response.json()
-    assert_paginated_response_data(response.json(), total=1)
-    assert_structure_data(structure_2, resp_data["items"][0])
 
 
 def test_list_services_unauthenticated(api_client):
@@ -271,10 +235,10 @@ def test_list_services_all(api_client):
                 "formulaire_en_ligne": None,
                 "frais_autres": "Camarade il.",
                 "frais": ["gratuit"],
-                "id": "be-water-scene-wind",
+                "id": "cacher-violent",
                 "justificatifs": [],
                 "latitude": -77.857573,
-                "lien_source": "https://dora.fr/be-water-scene-wind",
+                "lien_source": "https://dora.fr/cacher-violent",
                 "longitude": -62.54684,
                 "modes_accueil": ["a-distance"],
                 "modes_orientation_accompagnateur_autres": None,
@@ -291,7 +255,7 @@ def test_list_services_all(api_client):
                 "recurrence": None,
                 "score_qualite": 0.5,
                 "source": "dora",
-                "structure_id": "much-mention",
+                "structure_id": "prince-point-monde",
                 "telephone": "0102030405",
                 "thematiques": ["choisir-un-metier"],
                 "types": ["formation"],

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -294,24 +294,6 @@ def test_list_structures_order(
 
 @pytest.mark.with_token
 @pytest.mark.feature_deprecated
-def test_list_services_filter_by_source(api_client):
-    service_1 = factories.ServiceFactory(source="emplois-de-linclusion")
-    factories.ServiceFactory(source="dora")
-
-    url = "/api/v0/services/"
-    response = api_client.get(url, params={"source": "emplois-de-linclusion"})
-
-    assert response.status_code == 200
-
-    resp_data = response.json()
-
-    assert len(resp_data["items"]) == 1
-    assert resp_data["items"][0]["id"] == service_1.id
-    assert resp_data["items"][0]["source"] == service_1.structure.source
-
-
-@pytest.mark.with_token
-@pytest.mark.feature_deprecated
 def test_list_services_filter_by_thematique(api_client):
     service_1 = factories.ServiceFactory(
         source="alpha",


### PR DESCRIPTION
Un certain nombre de champs ont été dépréciés mais pas supprimés car toujours en usage chez certains conso.

[On retire la source dans structures car presque pas du tout utilisé en octobre et presque plus utilisé en septembre](https://metabase.data.inclusion.gouv.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InF1ZXJ5Ijp7ImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiYnJlYWtvdXQiOltbImZpZWxkIiwiY3JlYXRlZF9hdCIseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lV2l0aExvY2FsVFoiLCJ0ZW1wb3JhbC11bml0IjoibW9udGgifV0sWyJmaWVsZCIsInByb2R1Y3QiLHsiYmFzZS10eXBlIjoidHlwZS9UZXh0In1dLFsiZmllbGQiLCJlbmRwb2ludF9uYW1lIix7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XV0sInNvdXJjZS10YWJsZSI6ImNhcmRfXzI2MiIsImZpbHRlciI6WyJhbmQiLFsidGltZS1pbnRlcnZhbCIsWyJmaWVsZCIsImNyZWF0ZWRfYXQiLHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZVdpdGhMb2NhbFRaIn1dLC0zLCJtb250aCIseyJpbmNsdWRlLWN1cnJlbnQiOnRydWV9XSxbIm5vdC1lbXB0eSIsWyJmaWVsZCIsInF1ZXJ5X3BhcmFtc19fc291cmNlIix7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XV0sWyI9IixbImZpZWxkIiwiZW5kcG9pbnRfbmFtZSIseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV0sImxpc3Rfc3RydWN0dXJlc19lbmRwb2ludCJdXX0sInR5cGUiOiJxdWVyeSIsImRhdGFiYXNlIjo5fSwiZGlzcGxheSI6ImxpbmUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJ0YWJsZS5waXZvdF9jb2x1bW4iOiJtZXRob2QiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6InN0YXR1c19jb2RlIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjI2Mn0=)

[Même constat pour source dans services ](https://metabase.data.inclusion.gouv.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo5LCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJhZ2dyZWdhdGlvbiI6W1siY291bnQiXV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsImNyZWF0ZWRfYXQiLHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZVdpdGhMb2NhbFRaIiwidGVtcG9yYWwtdW5pdCI6Im1vbnRoIn1dLFsiZmllbGQiLCJwcm9kdWN0Iix7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSxbImZpZWxkIiwiZW5kcG9pbnRfbmFtZSIseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV1dLCJzb3VyY2UtdGFibGUiOiJjYXJkX18yNjIiLCJmaWx0ZXIiOlsiYW5kIixbInRpbWUtaW50ZXJ2YWwiLFsiZmllbGQiLCJjcmVhdGVkX2F0Iix7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWVXaXRoTG9jYWxUWiJ9XSwtMywibW9udGgiLHsiaW5jbHVkZS1jdXJyZW50Ijp0cnVlfV0sWyJub3QtZW1wdHkiLFsiZmllbGQiLCJxdWVyeV9wYXJhbXNfX3NvdXJjZSIseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV1dLFsiPSIsWyJmaWVsZCIsImVuZHBvaW50X25hbWUiLHsiYmFzZS10eXBlIjoidHlwZS9UZXh0In1dLCJsaXN0X3NlcnZpY2VzX2VuZHBvaW50Il1dfX0sImRpc3BsYXkiOiJsaW5lIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3RfY29sdW1uIjoibWV0aG9kIiwidGFibGUuY2VsbF9jb2x1bW4iOiJzdGF0dXNfY29kZSJ9LCJvcmlnaW5hbF9jYXJkX2lkIjoyNjJ9)

Pour les deux cas ci dessus, des tests avaient déjà été mis en place, j'ai donc juste effacé les tests depricated.
J'ai aussi du modifier des noms de structures & id dans `test_list_services_all` et `test_list_structures_all`


[Thematique](https://metabase.data.inclusion.gouv.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo5LCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJhZ2dyZWdhdGlvbiI6W1siY291bnQiXV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsImNyZWF0ZWRfYXQiLHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZVdpdGhMb2NhbFRaIiwidGVtcG9yYWwtdW5pdCI6Im1vbnRoIn1dLFsiZmllbGQiLCJwcm9kdWN0Iix7ImJhc2UtdHlwZSI6InR5cGUvVGV4dCJ9XSxbImZpZWxkIiwiZW5kcG9pbnRfbmFtZSIseyJiYXNlLXR5cGUiOiJ0eXBlL1RleHQifV1dLCJzb3VyY2UtdGFibGUiOiJjYXJkX18yNjIiLCJmaWx0ZXIiOlsiYW5kIixbInRpbWUtaW50ZXJ2YWwiLFsiZmllbGQiLCJjcmVhdGVkX2F0Iix7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWVXaXRoTG9jYWxUWiJ9XSwtMywibW9udGgiLHsiaW5jbHVkZS1jdXJyZW50Ijp0cnVlfV0sWyJub3QtZW1wdHkiLFsiZmllbGQiLCJxdWVyeV9wYXJhbXNfX3RoZW1hdGlxdWUiLHsiYmFzZS10eXBlIjoidHlwZS9UZXh0In1dXV19fSwiZGlzcGxheSI6ImxpbmUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6eyJ0YWJsZS5waXZvdF9jb2x1bW4iOiJtZXRob2QiLCJ0YWJsZS5jZWxsX2NvbHVtbiI6InN0YXR1c19jb2RlIn0sIm9yaWdpbmFsX2NhcmRfaWQiOjI2Mn0=) est encore utilisé donc on y touche pas.
