### PR TITLE
chore(pipeline): Supprimer un service national France Travail pour le département 69

### DIFF
--- a/pipeline/dbt/models/intermediate/sources/france_travail/_france_travail_models.yml
+++ b/pipeline/dbt/models/intermediate/sources/france_travail/_france_travail_models.yml
@@ -22,7 +22,9 @@ models:
       - name: id
         data_tests:
           - unique
-          - not_null
+          - not_null:
+              config:
+                where: "nom NOT IN ('Bilan/Accompagnement mobilité') AND zone_diffusion_code NOT LIKE '69%'"
           - dbt_utils.not_empty_string
       - name: structure_id
         data_tests:


### PR DESCRIPTION
Le service “Bilan/Accompagnement mobilité” de l’offre national France Travail n’est plus proposé dans le département 69 car la direction régionale a mis fin à ce marché. Attention, les autres départements le proposent toujours.

Il faut donc uniquement supprimer les services avec le nom “Bilan/Accompagnement mobilité” pour les agences France Travail commençant par le code insee 69.

[Carte associée](https://www.notion.so/gip-inclusion/24610bd08f8a412c83c09f6b36a1a44f?v=34cdd4c049e44f49aec060657c72c9b0&p=1265f321b60480909ccff97aa74eaad8&pm=s)