### PR TITLE
fix(fredo) : Blank the coordinates when address is null

### DIFF
--- a/pipeline/dbt/models/intermediate/sources/fredo/int_fredo__adresses.sql
+++ b/pipeline/dbt/models/intermediate/sources/fredo/int_fredo__adresses.sql
@@ -7,8 +7,12 @@ final AS (
         id            AS "id",
         commune       AS "commune",
         NULL          AS "code_insee",
-        longitude     AS "longitude",
-        latitude      AS "latitude",
+        CASE
+            WHEN adresse IS NOT NULL THEN latitude
+        END           AS "latitude",
+        CASE
+            WHEN adresse IS NOT NULL THEN longitude
+        END           AS "longitude",
         _di_source_id AS "source",
         code_postal   AS "code_postal",
         adresse       AS "adresse",


### PR DESCRIPTION
By the way, this should probably be enforced ?
Why would we get a lat/lon without an address ?

--------- BEFORE
data-inclusion=# select count(*) from public_intermediate.int_fredo__adresses where adresse is null and latitude is null;
 count
-------
    37
(1 row)

--------- AFTER
data-inclusion=# select count(*) from public_intermediate.int_fredo__adresses where adresse is null and latitude is null;
 count
-------
   247
(1 row)