### PR TITLE
feat(api): add dedicated analytics models

### DIFF
--- a/api/src/alembic/env.py
+++ b/api/src/alembic/env.py
@@ -3,6 +3,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from data_inclusion.api.analytics import models as _  # noqa: F401 F811
 from data_inclusion.api.config import settings
 from data_inclusion.api.core import db
 from data_inclusion.api.decoupage_administratif import models as _  # noqa: F401 F811

--- a/api/src/alembic/versions/20241203_175736_d5351b394a5e_create_analytics_tables.py
+++ b/api/src/alembic/versions/20241203_175736_d5351b394a5e_create_analytics_tables.py
@@ -1,0 +1,129 @@
+"""create analytics tables
+
+Revision ID: d5351b394a5e
+Revises: 68fe052dc63c
+Create Date: 2024-12-03 17:57:36.162644
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from data_inclusion.api.core.db import SortedTextArray
+
+# revision identifiers, used by Alembic.
+revision = "d5351b394a5e"
+down_revision = "68fe052dc63c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api__consult_service_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user", sa.String(), nullable=False),
+        sa.Column("service_id", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("score_qualite", sa.Float(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api__consult_service_events")),
+    )
+    op.create_table(
+        "api__consult_structure_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user", sa.String(), nullable=False),
+        sa.Column("structure_id", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api__consult_structure_events")),
+    )
+    op.create_table(
+        "api__list_services_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user", sa.String(), nullable=False),
+        sa.Column("sources", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("thematiques", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("code_departement", sa.String(), nullable=True),
+        sa.Column("code_region", sa.String(), nullable=True),
+        sa.Column("code_commune", sa.String(), nullable=True),
+        sa.Column("frais", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("profils", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("modes_accueil", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("types", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("inclure_suspendus", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api__list_services_events")),
+    )
+    op.create_table(
+        "api__list_structures_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user", sa.String(), nullable=False),
+        sa.Column("sources", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("structure_id", sa.String(), nullable=True),
+        sa.Column("typologie", sa.String(), nullable=True),
+        sa.Column("label_national", sa.String(), nullable=True),
+        sa.Column("code_departement", sa.String(), nullable=True),
+        sa.Column("code_region", sa.String(), nullable=True),
+        sa.Column("code_commune", sa.String(), nullable=True),
+        sa.Column("thematiques", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api__list_structures_events")),
+    )
+    op.create_table(
+        "api__search_services_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("user", sa.String(), nullable=False),
+        sa.Column(
+            "first_services",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("total_services", sa.Integer(), nullable=True),
+        sa.Column("sources", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("code_commune", sa.String(), nullable=True),
+        sa.Column("lat", sa.Float(), nullable=True),
+        sa.Column("lon", sa.Float(), nullable=True),
+        sa.Column("thematiques", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("frais", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("modes_accueil", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("profils", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("types", SortedTextArray(sa.VARCHAR()), nullable=True),
+        sa.Column("inclure_suspendus", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api__search_services_events")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api__search_services_events")
+    op.drop_table("api__list_structures_events")
+    op.drop_table("api__list_services_events")
+    op.drop_table("api__consult_structure_events")
+    op.drop_table("api__consult_service_events")

--- a/api/src/alembic/versions/20241205_143006_89e1ece4f56e_migrate_requests_to_analytics.py
+++ b/api/src/alembic/versions/20241205_143006_89e1ece4f56e_migrate_requests_to_analytics.py
@@ -1,0 +1,173 @@
+"""migrate requests to analytics
+
+Revision ID: 89e1ece4f56e
+Revises: d5351b394a5e
+Create Date: 2024-12-05 14:30:06.910343
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "89e1ece4f56e"
+down_revision = "d5351b394a5e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        INSERT INTO
+            public.api__consult_service_events(
+                id,
+                created_at,
+                "user",
+                source,
+                service_id
+            )
+        SELECT
+            id,
+            created_at,
+            "user",
+            path_params ->> 'source',
+            path_params ->> 'id'
+        FROM
+            public.api__requests
+        WHERE
+            status_code = 200
+            AND endpoint_name = 'retrieve_service_endpoint'
+    """)
+    op.execute("""
+        INSERT INTO
+            public.api__consult_structure_events(
+                id,
+                created_at,
+                "user",
+                source,
+                structure_id
+            )
+        SELECT
+            id,
+            created_at,
+            "user",
+            path_params ->> 'source',
+            path_params ->> 'id'
+        FROM
+            public.api__requests
+        WHERE
+            status_code = 200
+            AND endpoint_name = 'retrieve_structure_endpoint'
+    """)
+    op.execute("""
+        INSERT INTO
+            public.api__list_services_events(
+                id,
+                created_at,
+                "user",
+                code_region,
+                code_departement,
+                code_commune,
+                frais,
+                profils,
+                thematiques,
+                modes_accueil,
+                types,
+                inclure_suspendus,
+                sources
+            )
+        SELECT
+            id,
+            created_at,
+            "user",
+            query_params ->> 'code_region',
+            query_params ->> 'code_departement',
+            query_params ->> 'code_commune',
+            STRING_TO_ARRAY(query_params ->> 'frais', ','),
+            STRING_TO_ARRAY(query_params ->> 'profils', ','),
+            STRING_TO_ARRAY(query_params ->> 'thematiques', ','),
+            STRING_TO_ARRAY(query_params ->> 'modes_accueil', ','),
+            STRING_TO_ARRAY(query_params ->> 'types', ','),
+            CAST(query_params ->> 'inclure_suspendus' AS BOOLEAN),
+            STRING_TO_ARRAY(query_params ->> 'sources', ',')
+        FROM
+            public.api__requests
+        WHERE
+            status_code = 200
+            AND endpoint_name = 'list_services_endpoint'
+    """)
+    op.execute("""
+        INSERT INTO
+            public.api__list_structures_events(
+                id,
+                created_at,
+                "user",
+                structure_id,
+                typologie,
+                label_national,
+                thematiques,
+                code_region,
+                code_departement,
+                code_commune,
+                sources
+            )
+        SELECT
+            id,
+            created_at,
+            "user",
+            query_params ->> 'id',
+            query_params ->> 'typologie',
+            query_params ->> 'label_national',
+            STRING_TO_ARRAY(query_params ->> 'thematiques', ','),
+            query_params ->> 'code_region',
+            query_params ->> 'code_departement',
+            query_params ->> 'code_commune',
+            STRING_TO_ARRAY(query_params ->> 'sources', ',')
+        FROM
+            public.api__requests
+        WHERE
+            status_code = 200
+            AND endpoint_name = 'list_structures_endpoint'
+    """)
+    op.execute("""
+        INSERT INTO
+            public.api__search_services_events(
+                id,
+                created_at,
+                "user",
+                code_commune,
+                lat,
+                lon,
+                thematiques,
+                frais,
+                modes_accueil,
+                profils,
+                types,
+                inclure_suspendus,
+                sources
+            )
+        SELECT
+            id,
+            created_at,
+            "user",
+            query_params ->> 'code_commune',
+            CAST(query_params ->> 'lat' AS FLOAT),
+            CAST(query_params ->> 'lon' AS FLOAT),
+            STRING_TO_ARRAY(query_params ->> 'thematiques', ','),
+            STRING_TO_ARRAY(query_params ->> 'frais', ','),
+            STRING_TO_ARRAY(query_params ->> 'modes_accueil', ','),
+            STRING_TO_ARRAY(query_params ->> 'profils', ','),
+            STRING_TO_ARRAY(query_params ->> 'types', ','),
+            COALESCE(CAST(query_params ->> 'inclure_suspendus' AS BOOLEAN), FALSE),
+            STRING_TO_ARRAY(query_params ->> 'sources', ',')
+        FROM
+            public.api__requests
+        WHERE
+            status_code = 200
+            AND (query_params ->> 'lat') NOT LIKE '%,%'
+            AND (query_params ->> 'lon') NOT LIKE '%,%'
+            AND endpoint_name = 'search_services_endpoint'
+    """)
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/data_inclusion/api/analytics/models.py
+++ b/api/src/data_inclusion/api/analytics/models.py
@@ -1,0 +1,68 @@
+from sqlalchemy.orm import Mapped
+
+from data_inclusion.api.core import db
+
+
+class ConsultStructureEvent(db.Base):
+    id: Mapped[db.uuid_pk]
+    created_at: Mapped[db.timestamp]
+    user: Mapped[str]
+    structure_id: Mapped[str]
+    source: Mapped[str]
+
+
+class ConsultServiceEvent(db.Base):
+    id: Mapped[db.uuid_pk]
+    created_at: Mapped[db.timestamp]
+    user: Mapped[str]
+    service_id: Mapped[str]
+    source: Mapped[str]
+    score_qualite: Mapped[float | None]
+
+
+class ListServicesEvent(db.Base):
+    id: Mapped[db.uuid_pk]
+    created_at: Mapped[db.timestamp]
+    user: Mapped[str]
+    sources: Mapped[list[str] | None]
+    thematiques: Mapped[list[str] | None]
+    code_departement: Mapped[str | None]
+    code_region: Mapped[str | None]
+    code_commune: Mapped[str | None]
+    frais: Mapped[list[str] | None]
+    profils: Mapped[list[str] | None]
+    modes_accueil: Mapped[list[str] | None]
+    types: Mapped[list[str] | None]
+    inclure_suspendus: Mapped[bool | None]
+
+
+class ListStructuresEvent(db.Base):
+    id: Mapped[db.uuid_pk]
+    created_at: Mapped[db.timestamp]
+    user: Mapped[str]
+    sources: Mapped[list[str] | None]
+    structure_id: Mapped[str | None]
+    typologie: Mapped[str | None]
+    label_national: Mapped[str | None]
+    code_departement: Mapped[str | None]
+    code_region: Mapped[str | None]
+    code_commune: Mapped[str | None]
+    thematiques: Mapped[list[str] | None]
+
+
+class SearchServicesEvent(db.Base):
+    id: Mapped[db.uuid_pk]
+    created_at: Mapped[db.timestamp]
+    user: Mapped[str]
+    first_services: Mapped[list[dict] | None]
+    total_services: Mapped[int | None]
+    sources: Mapped[list[str] | None]
+    code_commune: Mapped[str | None]
+    lat: Mapped[float | None]
+    lon: Mapped[float | None]
+    thematiques: Mapped[list[str] | None]
+    frais: Mapped[list[str] | None]
+    modes_accueil: Mapped[list[str] | None]
+    profils: Mapped[list[str] | None]
+    types: Mapped[list[str] | None]
+    inclure_suspendus: Mapped[bool | None]

--- a/api/src/data_inclusion/api/analytics/services.py
+++ b/api/src/data_inclusion/api/analytics/services.py
@@ -1,0 +1,167 @@
+from sqlalchemy import orm
+
+import fastapi
+
+from data_inclusion import schema as di_schema
+from data_inclusion.api.analytics.models import (
+    ConsultServiceEvent,
+    ConsultStructureEvent,
+    ListServicesEvent,
+    ListStructuresEvent,
+    SearchServicesEvent,
+)
+from data_inclusion.api.decoupage_administratif.constants import (
+    Departement,
+    Region,
+)
+from data_inclusion.api.inclusion_data import schemas
+from data_inclusion.api.utils import pagination
+
+
+def save_consult_structure_event(
+    request: fastapi.Request,
+    structure: schemas.DetailedStructure,
+    db_session: orm.Session,
+):
+    user = request.scope.get("user")
+    if user is None or not user.is_authenticated:
+        return
+
+    event = ConsultStructureEvent(
+        structure_id=structure.id, source=structure.source, user=user.username
+    )
+    db_session.add(event)
+    db_session.commit()
+
+
+def save_consult_service_event(
+    request: fastapi.Request,
+    service: schemas.DetailedService,
+    db_session: orm.Session,
+):
+    user = request.scope.get("user")
+    if user is None or not user.is_authenticated:
+        return
+
+    event = ConsultServiceEvent(
+        service_id=service.id,
+        source=service.source,
+        user=user.username,
+        score_qualite=service.score_qualite,
+    )
+    db_session.add(event)
+    db_session.commit()
+
+
+def save_list_services_event(
+    request: fastapi.Request,
+    db_session: orm.Session,
+    sources: list[str] | None = None,
+    thematiques: list[di_schema.Thematique] | None = None,
+    departement: Departement | None = None,
+    region: Region | None = None,
+    code_commune: di_schema.CodeCommune | None = None,
+    frais: list[di_schema.Frais] | None = None,
+    profils: list[di_schema.Profil] | None = None,
+    modes_accueil: list[di_schema.ModeAccueil] | None = None,
+    types: list[di_schema.TypologieService] | None = None,
+    inclure_suspendus: bool | None = False,
+):
+    user = request.scope.get("user")
+    if user is None or not user.is_authenticated:
+        return
+
+    event = ListServicesEvent(
+        user=user.username,
+        sources=sources,
+        thematiques=thematiques,
+        code_departement=departement.code if departement else None,
+        code_region=region.code if region else None,
+        code_commune=code_commune,
+        frais=frais,
+        profils=profils,
+        modes_accueil=modes_accueil,
+        types=types,
+        inclure_suspendus=inclure_suspendus,
+    )
+    db_session.add(event)
+    db_session.commit()
+
+
+def save_list_structures_event(
+    request: fastapi.Request,
+    db_session: orm.Session,
+    sources: list[str] | None = None,
+    structure_id: str | None = None,
+    typologie: di_schema.Typologie | None = None,
+    label_national: di_schema.LabelNational | None = None,
+    departement: Departement | None = None,
+    region: Region | None = None,
+    code_commune: di_schema.CodeCommune | None = None,
+    thematiques: list[di_schema.Thematique] | None = None,
+):
+    user = request.scope.get("user")
+    if user is None or not user.is_authenticated:
+        return
+
+    event = ListStructuresEvent(
+        user=user.username,
+        sources=sources,
+        structure_id=structure_id,
+        typologie=typologie,
+        label_national=label_national,
+        code_departement=departement.code if departement else None,
+        code_region=region.code if region else None,
+        code_commune=code_commune,
+        thematiques=thematiques,
+    )
+    db_session.add(event)
+    db_session.commit()
+
+
+def save_search_services_event(
+    request: fastapi.Request,
+    db_session: orm.Session,
+    results: pagination.BigPage[schemas.ServiceSearchResult],
+    sources: list[str] | None = None,
+    code_commune: str | None = None,
+    lat: float | None = None,
+    lon: float | None = None,
+    thematiques: list[di_schema.Thematique] | None = None,
+    frais: list[di_schema.Frais] | None = None,
+    modes_accueil: list[di_schema.ModeAccueil] | None = None,
+    profils: list[di_schema.Profil] | None = None,
+    types: list[di_schema.TypologieService] | None = None,
+    inclure_suspendus: bool | None = False,
+):
+    user = request.scope.get("user")
+    if user is None or not user.is_authenticated:
+        return
+
+    if results.page is not None and results.page > 1:
+        return
+
+    event = SearchServicesEvent(
+        user=user.username,
+        first_services=[
+            {
+                "id": result.service.id,
+                "score_qualite": result.service.score_qualite,
+                "distance": result.distance,
+            }
+            for result in results.items[:10]
+        ],
+        total_services=results.total,
+        sources=sources,
+        code_commune=code_commune,
+        lat=lat,
+        lon=lon,
+        thematiques=thematiques,
+        frais=frais,
+        modes_accueil=modes_accueil,
+        profils=profils,
+        types=types,
+        inclure_suspendus=inclure_suspendus,
+    )
+    db_session.add(event)
+    db_session.commit()

--- a/api/src/data_inclusion/api/core/db.py
+++ b/api/src/data_inclusion/api/core/db.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import datetime
 from typing import Annotated
@@ -44,6 +45,7 @@ class Base(orm.DeclarativeBase):
     )
     type_annotation_map = {
         list[str]: SortedTextArray,
+        list[dict]: JSONB,
         dict: JSONB,
     }
 
@@ -52,7 +54,8 @@ class Base(orm.DeclarativeBase):
 
     @orm.declared_attr.directive
     def __tablename__(cls) -> str:
-        return f"api__{cls.__name__}s".lower()
+        snake_case_name = re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__).lower()
+        return f"api__{snake_case_name}s"
 
 
 def get_session(request: fastapi.Request):

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -253,9 +253,7 @@ def read_sources():
 def list_sources(request: fastapi.Request) -> list[dict]:
     sources = read_sources()
     if not request.user.is_authenticated or "dora" not in request.user.username:
-        sources = [
-            d for d in sources if d["slug"] not in ["data-inclusion", "soliguide"]
-        ]
+        sources = [d for d in sources if d["slug"] not in ["soliguide"]]
     return sources
 
 

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -202,14 +202,14 @@ def list_structures(
     if departement is not None:
         query = query.filter(models.Structure.code_insee.startswith(departement.code))
 
+    if typologie is not None:
+        query = query.filter_by(typologie=typologie.value)
+
     if region is not None:
         query = query.join(Commune).options(
             orm.contains_eager(models.Structure.commune_)
         )
         query = query.filter(Commune.region == region.code)
-
-    if typologie is not None:
-        query = query.filter_by(typologie=typologie.value)
 
     if label_national is not None:
         query = query.filter(

--- a/api/src/data_inclusion/api/inclusion_data/sources.json
+++ b/api/src/data_inclusion/api/inclusion_data/sources.json
@@ -15,11 +15,6 @@
         "description": "Contient les structures et services inclusifs du département de l’Ille-et-Vilaine."
     },
     {
-        "slug": "data-inclusion",
-        "nom": "Expérimentation data·inclusion en Essonne",
-        "description": "Expérimentation data·inclusion en Essonne."
-    },
-    {
         "slug": "dora",
         "nom": "DORA",
         "description": "Service public numérique de recensement de l’offre d’insertion développé par la Plateforme de l’inclusion. Contient leurs structures et services inclusifs sur de nombreuses thématiques."

--- a/api/src/data_inclusion/api/utils/pagination.py
+++ b/api/src/data_inclusion/api/utils/pagination.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import fastapi
 from fastapi_pagination import Page
 from fastapi_pagination.customization import (
@@ -8,8 +10,10 @@ from fastapi_pagination.customization import (
 
 from data_inclusion.api.config import settings
 
+T = TypeVar("T")
+
 BigPage = CustomizedPage[
-    Page,
+    Page[T],
     UseName("CustomizedPage"),
     UseParamsFields(
         size=fastapi.Query(

--- a/api/tests/e2e/api/test_analytics.py
+++ b/api/tests/e2e/api/test_analytics.py
@@ -1,0 +1,241 @@
+import pytest
+import sqlalchemy as sqla
+
+from data_inclusion.api.analytics import models
+
+from ... import factories
+
+DUNKERQUE = {"code_insee": "59183", "latitude": 51.0361, "longitude": 2.3770}
+HAZEBROUCK = {"code_insee": "59295", "latitude": 50.7262, "longitude": 2.5387}
+
+
+@pytest.mark.parametrize(
+    ("url", "model"),
+    [
+        ("/api/v0/structures/foo/bar", models.ConsultStructureEvent),
+        ("/api/v0/services/foo/bar", models.ConsultServiceEvent),
+    ],
+)
+@pytest.mark.with_token
+def test_ignore_event_if_resource_not_found(api_client, db_session, url, model):
+    response = api_client.get(url)
+
+    assert response.status_code == 404
+    assert db_session.scalar(sqla.select(sqla.func.count()).select_from(model)) == 0
+
+
+@pytest.mark.with_token
+def test_consult_structure_event_saved(api_client, db_session):
+    structure = factories.StructureFactory(source="foo", id="1")
+    url = f"/api/v0/structures/{structure.source}/{structure.id}"
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.ConsultStructureEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.ConsultStructureEvent)).first()
+    assert event.user == "some_user"
+    assert event.structure_id == structure.id
+    assert event.source == structure.source
+
+
+@pytest.mark.with_token
+def test_consult_service_event_saved(api_client, db_session):
+    service = factories.ServiceFactory(source="foo", id="1", score_qualite=0.8)
+    url = f"/api/v0/services/{service.source}/{service.id}"
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.ConsultServiceEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.ConsultServiceEvent)).first()
+    assert event.user == "some_user"
+    assert event.service_id == service.id
+    assert event.source == service.source
+    assert event.score_qualite == service.score_qualite
+
+
+@pytest.mark.with_token
+def test_list_services_event_saved(api_client, db_session):
+    url = "/api/v0/services"
+    query_param = {
+        "sources": ["foo"],
+        "thematiques": ["acces-aux-droits-et-citoyennete"],
+        "code_departement": "26",
+        "code_region": "84",
+        "code_commune": "26400",
+        "frais": ["gratuit"],
+        "profils": ["adultes"],
+        "modes_accueil": ["a-distance"],
+        "types": ["accompagnement"],
+        "inclure_suspendus": 1,
+    }
+    response = api_client.get(url, params=query_param)
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.ListServicesEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.ListServicesEvent)).first()
+    assert event.user == "some_user"
+    assert event.sources == query_param["sources"]
+    assert event.thematiques == query_param["thematiques"]
+    assert event.code_departement == query_param["code_departement"]
+    assert event.code_region == query_param["code_region"]
+    assert event.code_commune == query_param["code_commune"]
+    assert event.frais == query_param["frais"]
+    assert event.profils == query_param["profils"]
+    assert event.modes_accueil == query_param["modes_accueil"]
+    assert event.types == query_param["types"]
+    assert event.inclure_suspendus == query_param["inclure_suspendus"]
+
+
+@pytest.mark.with_token
+def test_list_structures_event_saved(api_client, db_session):
+    url = "/api/v0/structures"
+    query_param = {
+        "sources": ["foo"],
+        "thematiques": ["acces-aux-droits-et-citoyennete"],
+        "code_departement": "26",
+        "code_region": "84",
+        "code_commune": "26400",
+        "typologie": "ACIPHC",
+        "id": "1",
+        "label_national": "action-logement",
+    }
+    response = api_client.get(url, params=query_param)
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.ListStructuresEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.ListStructuresEvent)).first()
+    assert event.user == "some_user"
+    assert event.sources == query_param["sources"]
+    assert event.thematiques == query_param["thematiques"]
+    assert event.code_departement == query_param["code_departement"]
+    assert event.code_region == query_param["code_region"]
+    assert event.code_commune == query_param["code_commune"]
+    assert event.typologie == query_param["typologie"]
+    assert event.structure_id == query_param["id"]
+    assert event.label_national == query_param["label_national"]
+
+
+@pytest.mark.with_token
+def test_search_services_event_saved(api_client, db_session):
+    url = "/api/v0/search/services"
+    query_param = {
+        "sources": ["foo"],
+        "thematiques": ["acces-aux-droits-et-citoyennete"],
+        "code_commune": HAZEBROUCK["code_insee"],
+        "code_insee": DUNKERQUE["code_insee"],
+        "frais": ["gratuit"],
+        "profils": ["adultes"],
+        "profils_precisions": "test",
+        "modes_accueil": ["a-distance"],
+        "types": ["accompagnement"],
+        "inclure_suspendus": True,
+        "lat": 45.0,
+        "lon": 5.0,
+    }
+    response = api_client.get(url, params=query_param)
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.SearchServicesEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.SearchServicesEvent)).first()
+
+    assert event.user == "some_user"
+    assert len(event.first_services) == 0
+    assert event.total_services == 0
+    assert event.sources == query_param["sources"]
+    assert event.thematiques == query_param["thematiques"]
+    assert event.code_commune == query_param["code_commune"]
+    assert event.lat == query_param["lat"]
+    assert event.lon == query_param["lon"]
+    assert event.frais == query_param["frais"]
+    assert event.profils == query_param["profils"]
+    assert event.modes_accueil == query_param["modes_accueil"]
+    assert event.types == query_param["types"]
+    assert event.inclure_suspendus == query_param["inclure_suspendus"]
+
+
+@pytest.mark.with_token
+def test_search_services_event_saved_with_results(api_client, db_session):
+    number_of_results_to_saved = 10
+
+    for _ in range(number_of_results_to_saved + 1):
+        factories.ServiceFactory()
+
+    response = api_client.get("/api/v0/search/services")
+
+    assert response.status_code == 200
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.SearchServicesEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.SearchServicesEvent)).first()
+    assert event.user == "some_user"
+    assert event.first_services == [
+        {
+            "id": item["service"]["id"],
+            "score_qualite": item["service"]["score_qualite"],
+            "distance": item["distance"],
+        }
+        for item in response.json()["items"][:number_of_results_to_saved]
+    ]
+    assert event.total_services == response.json()["total"]
+
+
+@pytest.mark.with_token
+def test_search_services_event_only_first_page_saved(api_client, db_session):
+    factories.ServiceFactory()
+    factories.ServiceFactory()
+
+    first_response = api_client.get(
+        "/api/v0/search/services", params={"size": 1, "page": 1}
+    )
+    api_client.get("/api/v0/search/services", params={"size": 1, "page": 2})
+
+    assert (
+        db_session.scalar(
+            sqla.select(sqla.func.count()).select_from(models.SearchServicesEvent)
+        )
+        == 1
+    )
+
+    event = db_session.scalars(sqla.select(models.SearchServicesEvent)).first()
+    assert event.first_services == [
+        {
+            "id": item["service"]["id"],
+            "score_qualite": item["service"]["score_qualite"],
+            "distance": item["distance"],
+        }
+        for item in first_response.json()["items"]
+    ]


### PR DESCRIPTION
Sur un export du 2 decembre de prod:

  | Nombre d’entree | Date de la plus vieille entree
-- | -- | --
api__consult_service_events | 1336943 | 2023-07-03 21:31:46.365 +0200
api__consult_structure_events | 23120 | 2023-08-01 20:54:31.693 +0200
api__list_services_events | 116636 | 2023-07-03 20:21:19.939 +0200
api__list_structures_events | 122641 | 2023-07-04 10:54:26.028 +0200
api__services_searchs | 74864 | 2024-01-22 14:21:42.841 +0100


`api__consult_service_events` et `api__consult_structure_events` n'ont pas de score_qualite apres migration (normal):

Taux de remplissage pour les colonnes de `api__list_services_events`:
sources_fill_rate | thematiques_fill_rate | departement_fill_rate | region_fill_rate | code_commune_fill_rate | frais_fill_rate | profils_fill_rate | modes_accueil_fill_rate | types_fill_rate | inclure_suspendus_fill_rate
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0.0938046572241846 | 0.00635309852875613 | 0.0296563668164203 | 0.000008573682225 | 0.00959395040982201 | 0 | 0 | 0 | 0.000008573682225 | 0.0121146129839844

Taux de remplissage pour les colonnes de `api__list_structure_events`:
sources_fill_rate | thematiques_fill_rate | departement_fill_rate | region_fill_rate | code_commune_fill_rate | frais_fill_rate | profils_fill_rate | modes_accueil_fill_rate
-- | -- | -- | -- | -- | -- | -- | --
0.0683621301196174 | 0.41523634021249 | 0.0128749765575949 | 0.000040769400119 | 0.00512879053497607 | 0 | 0.00287831964840469 | 0.00301693560880945

Taux de remplissage pour `api__services_searchs`:
total_services_count_fill_rate | code_commune_fill_rate | lat_fill_rate | lon_fill_rate | sources_fill_rate | thematiques_fill_rate | frais_fill_rate | modes_accueil_fill_rate | profils_fill_rate | types_fill_rate | include_outdated_fill_rate |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 0 | 1 | 1 | 0.998303590510793 | 0.824628659970079 | 0.0193550972430006 | 0 | 0 | 0.0337678991237444 | 1 |  

