### PR TITLE
feat(api) : Ajout du paramètre "deduplicate" sur la liste des structures

### DIFF
--- a/api/src/alembic/versions/20250206_145025_45104a7fe9e8_add_score_qualite_and_doublons_to_structures.py
+++ b/api/src/alembic/versions/20250206_145025_45104a7fe9e8_add_score_qualite_and_doublons_to_structures.py
@@ -1,4 +1,4 @@
-"""Add score_qualite to structures
+"""Add score_qualite and doublons to structures
 
 Revision ID: 45104a7fe9e8
 Revises: a06b6f7d1cbe
@@ -20,9 +20,14 @@ def upgrade() -> None:
     op.add_column(
         "api__structures", sa.Column("score_qualite", sa.Float(), nullable=True)
     )
+    op.add_column(
+        "api__structures",
+        sa.Column("doublons", sa.JSON(), nullable=True),
+    )
     op.execute("UPDATE api__structures SET score_qualite = 0.0")
     op.alter_column("api__structures", "score_qualite", nullable=False)
 
 
 def downgrade() -> None:
+    op.drop_column("api__structures", "doublons")
     op.drop_column("api__structures", "score_qualite")

--- a/api/src/alembic/versions/20250206_145025_45104a7fe9e8_add_score_qualite_to_structures.py
+++ b/api/src/alembic/versions/20250206_145025_45104a7fe9e8_add_score_qualite_to_structures.py
@@ -1,0 +1,28 @@
+"""Add score_qualite to structures
+
+Revision ID: 45104a7fe9e8
+Revises: a06b6f7d1cbe
+Create Date: 2025-02-06 14:50:25.092515
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "45104a7fe9e8"
+down_revision = "a06b6f7d1cbe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api__structures", sa.Column("score_qualite", sa.Float(), nullable=True)
+    )
+    op.execute("UPDATE api__structures SET score_qualite = 0.0")
+    op.alter_column("api__structures", "score_qualite", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("api__structures", "score_qualite")

--- a/api/src/data_inclusion/api/inclusion_data/commands.py
+++ b/api/src/data_inclusion/api/inclusion_data/commands.py
@@ -144,6 +144,16 @@ def load_inclusion_data():
             )
         ]
 
+    service_scores = (
+        services_df.groupby("_di_structure_surrogate_id")["score_qualite"]
+        .mean()
+        .round(2)
+    )
+
+    structures_df["score_qualite"] = (
+        structures_df["_di_surrogate_id"].map(service_scores).fillna(0.0)
+    )
+
     structure_data_list = structures_df.sort_values(
         by="_di_surrogate_id", ascending=True
     ).to_dict(orient="records")

--- a/api/src/data_inclusion/api/inclusion_data/models.py
+++ b/api/src/data_inclusion/api/inclusion_data/models.py
@@ -44,6 +44,8 @@ class Structure(Base):
     thematiques: Mapped[list[str] | None]
     typologie: Mapped[str | None]
 
+    score_qualite: Mapped[float]
+
     cluster_id: Mapped[str | None]
 
     doublons: Mapped[list["Structure"]] = relationship(

--- a/api/src/data_inclusion/api/inclusion_data/models.py
+++ b/api/src/data_inclusion/api/inclusion_data/models.py
@@ -48,17 +48,7 @@ class Structure(Base):
 
     cluster_id: Mapped[str | None]
 
-    doublons: Mapped[list["Structure"]] = relationship(
-        primaryjoin=(
-            "and_("
-            "foreign(Structure.cluster_id)==remote(Structure.cluster_id)"
-            ", "
-            "foreign(Structure._di_surrogate_id)!=remote(Structure._di_surrogate_id)"
-            ")"
-        ),
-        viewonly=True,
-        uselist=True,
-    )
+    doublons: Mapped[list[dict] | None]
 
     services: Mapped[list["Service"]] = relationship(back_populates="structure")
     commune_: Mapped[Commune] = relationship(back_populates="structures")

--- a/api/src/data_inclusion/api/inclusion_data/routes.py
+++ b/api/src/data_inclusion/api/inclusion_data/routes.py
@@ -88,6 +88,15 @@ def list_structures_endpoint(
     code_departement: CodeDepartementFilter = None,
     slug_departement: Annotated[Optional[DepartementSlugEnum], fastapi.Query()] = None,
     code_commune: CodeCommuneFilter = None,
+    exclure_doublons: Annotated[
+        Optional[bool],
+        fastapi.Query(
+            description=(
+                "[BETA] Mode qui ne retourne parmi les structures en doublon, que "
+                "celles ayant les services les plus qualitatifs (voir documentation)."
+            )
+        ),
+    ] = False,
     db_session=fastapi.Depends(db.get_session),
 ):
     region = get_region_by_code_or_slug(code=code_region, slug=slug_region)
@@ -106,6 +115,7 @@ def list_structures_endpoint(
         region=region,
         commune_code=code_commune,
         thematiques=thematiques,
+        deduplicate=exclure_doublons,
     )
 
     background_tasks.add_task(

--- a/api/src/data_inclusion/api/inclusion_data/schemas.py
+++ b/api/src/data_inclusion/api/inclusion_data/schemas.py
@@ -44,6 +44,18 @@ class Structure(schema.Structure):
         str | None,
         Field(description="ID du groupe de doublons", alias="doublons_groupe_id"),
     ]
+    score_qualite: Annotated[
+        float,
+        Field(
+            ge=0,
+            le=1,
+            description=dedent("""\
+                [BETA] Score de qualité de la structure. Défini comme la moyenne
+                des scores de qualité des services associés à la structure, ou 0
+                si aucun service n'est associé.
+                """),
+        ),
+    ]
 
 
 class DetailedService(Service):

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -205,9 +205,7 @@ def list_structures(
     thematiques: list[di_schema.Thematique] | None = None,
     deduplicate: bool = False,
 ) -> list:
-    query = sqla.select(models.Structure).options(
-        orm.joinedload(models.Structure.doublons)
-    )
+    query = sqla.select(models.Structure)
     query = filter_restricted(query, request)
 
     if sources is not None:

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -203,6 +203,7 @@ def list_structures(
     region: Region | None = None,
     commune_code: di_schema.CodeCommune | None = None,
     thematiques: list[di_schema.Thematique] | None = None,
+    deduplicate: bool = False,
 ) -> list:
     query = sqla.select(models.Structure).options(
         orm.joinedload(models.Structure.doublons)
@@ -239,6 +240,52 @@ def list_structures(
 
     if thematiques is not None:
         query = filter_structures_by_thematiques(query, thematiques)
+
+    if deduplicate:
+        max_scores = (
+            sqla.select(
+                models.Structure.cluster_id,
+                func.max(models.Structure.score_qualite).label("max_score"),
+            )
+            .where(models.Structure.cluster_id.is_not(None))
+            .group_by(models.Structure.cluster_id)
+            .subquery()
+        )
+        latest_updates = (
+            sqla.select(
+                models.Structure.cluster_id,
+                models.Structure.score_qualite,
+                func.max(models.Structure.date_maj).label("latest_date"),
+            )
+            .where(models.Structure.cluster_id.is_not(None))
+            .group_by(models.Structure.cluster_id, models.Structure.score_qualite)
+            .subquery()
+        )
+        query = (
+            query.filter(
+                sqla.or_(
+                    models.Structure.cluster_id.is_(None),
+                    sqla.and_(
+                        models.Structure.cluster_id == max_scores.c.cluster_id,
+                        models.Structure.score_qualite == max_scores.c.max_score,
+                        models.Structure.date_maj == latest_updates.c.latest_date,
+                    ),
+                )
+            )
+            .join(
+                max_scores,
+                models.Structure.cluster_id == max_scores.c.cluster_id,
+                isouter=True,
+            )
+            .join(
+                latest_updates,
+                sqla.and_(
+                    models.Structure.cluster_id == latest_updates.c.cluster_id,
+                    models.Structure.score_qualite == latest_updates.c.score_qualite,
+                ),
+                isouter=True,
+            )
+        )
 
     return paginate(db_session, query)
 

--- a/api/tests/e2e/api/__snapshots__/test_inclusion_data.ambr
+++ b/api/tests/e2e/api/__snapshots__/test_inclusion_data.ambr
@@ -128,6 +128,18 @@
               "description": "Code insee géographique d'une commune."
             },
             {
+              "name": "exclure_doublons",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "boolean",
+                "description": "[BETA] Mode qui ne retourne parmi les structures en doublon, que celles ayant les services les plus qualitatifs (voir documentation).",
+                "default": false,
+                "title": "Exclure Doublons"
+              },
+              "description": "[BETA] Mode qui ne retourne parmi les structures en doublon, que celles ayant les services les plus qualitatifs (voir documentation)."
+            },
+            {
               "name": "page",
               "in": "query",
               "required": false,
@@ -2259,6 +2271,13 @@
               "title": "Doublons Groupe Id",
               "description": "ID du groupe de doublons"
             },
+            "score_qualite": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Score Qualite",
+              "description": "[BETA] Score de qualité de la structure. Défini comme la moyenne\ndes scores de qualité des services associés à la structure, ou 0\nsi aucun service n'est associé.\n"
+            },
             "doublons": {
               "items": {
                 "$ref": "#/components/schemas/data_inclusion__schema__structures__Structure"
@@ -2282,6 +2301,7 @@
             "source",
             "date_maj",
             "doublons_groupe_id",
+            "score_qualite",
             "doublons",
             "services"
           ],
@@ -2738,6 +2758,13 @@
               "title": "Doublons Groupe Id",
               "description": "ID du groupe de doublons"
             },
+            "score_qualite": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Score Qualite",
+              "description": "[BETA] Score de qualité de la structure. Défini comme la moyenne\ndes scores de qualité des services associés à la structure, ou 0\nsi aucun service n'est associé.\n"
+            },
             "doublons": {
               "items": {
                 "$ref": "#/components/schemas/SourceIdDict"
@@ -2754,6 +2781,7 @@
             "source",
             "date_maj",
             "doublons_groupe_id",
+            "score_qualite",
             "doublons"
           ],
           "title": "ListedStructure"
@@ -4093,6 +4121,13 @@
               ],
               "title": "Doublons Groupe Id",
               "description": "ID du groupe de doublons"
+            },
+            "score_qualite": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Score Qualite",
+              "description": "[BETA] Score de qualité de la structure. Défini comme la moyenne\ndes scores de qualité des services associés à la structure, ou 0\nsi aucun service n'est associé.\n"
             }
           },
           "type": "object",
@@ -4101,7 +4136,8 @@
             "nom",
             "source",
             "date_maj",
-            "doublons_groupe_id"
+            "doublons_groupe_id",
+            "score_qualite"
           ],
           "title": "Structure"
         },

--- a/api/tests/e2e/api/test_inclusion_commands.py
+++ b/api/tests/e2e/api/test_inclusion_commands.py
@@ -1,0 +1,70 @@
+import pandas as pd
+
+from data_inclusion.api.core import db
+from data_inclusion.api.inclusion_data import commands, models
+
+
+def test_store_inclusion_data_scores_doublons(db_session):
+    structures_df = pd.DataFrame(
+        {
+            "_di_surrogate_id": ["s1", "s2", "s3"],
+            "id": ["id1", "id2", "id3"],
+            "nom": ["Structure 1", "Structure 2", "Structure 3"],
+            "date_maj": ["2023-01-01", "2023-01-01", "2023-01-01"],
+            "source": ["source1", "source2", "source1"],
+            "cluster_id": ["cluster1", "cluster1", None],
+        }
+    )
+
+    services_df = pd.DataFrame(
+        {
+            "_di_surrogate_id": ["sv1", "sv2", "sv3"],
+            "_di_structure_surrogate_id": ["s1", "s1", "s2"],
+            "id": ["sid1", "sid2", "sid3"],
+            "source": ["source1", "source1", "source2"],
+            "nom": ["Service 1", "Service 2", "Service 3"],
+            "date_maj": ["2023-01-01", "2023-01-01", "2023-01-01"],
+            "score_qualite": [0.7, 0.8, 0.5],
+        }
+    )
+
+    commands.store_inclusion_data(db_session, structures_df, services_df)
+
+    with db.SessionLocal() as session:
+        db_structures = session.query(models.Structure).all()
+        structures_by_id = {s.id: s for s in db_structures}
+        assert structures_by_id["id1"].score_qualite == 0.75  # average of 0.7 and 0.8
+        assert structures_by_id["id1"].doublons == [
+            {
+                "accessibilite": None,
+                "adresse": None,
+                "antenne": None,
+                "code_insee": None,
+                "code_postal": None,
+                "commune": None,
+                "complement_adresse": None,
+                "courriel": None,
+                "date_maj": "2023-01-01",
+                "horaires_ouverture": None,
+                "id": "id2",
+                "labels_autres": None,
+                "labels_nationaux": None,
+                "latitude": None,
+                "lien_source": None,
+                "longitude": None,
+                "nom": "Structure 2",
+                "presentation_detail": None,
+                "presentation_resume": None,
+                "rna": None,
+                "siret": None,
+                "site_web": None,
+                "source": "source2",
+                "telephone": None,
+                "thematiques": None,
+                "typologie": None,
+            }
+        ]
+        assert structures_by_id["id2"].score_qualite == 0.5
+        assert structures_by_id["id2"].doublons[0]["id"] == "id1"
+        assert structures_by_id["id3"].score_qualite == 0.0  # no services, default to 0
+        assert structures_by_id["id3"].doublons == []

--- a/api/tests/factories.py
+++ b/api/tests/factories.py
@@ -56,6 +56,7 @@ class StructureFactory(factory.alchemy.SQLAlchemyModelFactory):
         ],
         getter=lambda v: [v.value],
     )
+    score_qualite = 0.0
 
 
 class ServiceFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/api/tests/factories.py
+++ b/api/tests/factories.py
@@ -57,6 +57,7 @@ class StructureFactory(factory.alchemy.SQLAlchemyModelFactory):
         getter=lambda v: [v.value],
     )
     score_qualite = 0.0
+    doublons = []
 
 
 class ServiceFactory(factory.alchemy.SQLAlchemyModelFactory):


### PR DESCRIPTION
Nécessite https://github.com/gip-inclusion/data-inclusion-schema/pull/35 installé (API & DWH)

Le premier commit n'est pas à relire dans cette PR, il reprend les changements de la PR #374 .

Un squash sera nécessaire entre les deux PR (d'une certaine manière !) pour résoudre le souci lié au snapshot OpenAPI qui a fait des siennes dans les deux PR, au moins ici il est traité dans un commit à part pour simplifier la relecture.
