### PR TITLE
chore(github) : Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+[Lien vers le ticket notion associé]()
+
+### Checklist
+
+* [ ] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
+  * `<type>(<optional scope>): <description>`
+  * types : `feat`, `chore`, `fix`, `docs`, etc.
+  * scopes : `api`, `deployment`, `pipeline`, etc.
+* [ ] Je n'utilise pas l'anglais dans le schéma, la documentation, les PRs
+  * anglais ok pour le nommage des variables, la documentation, les messages de commit
+* Je respecte les règles de français dans le schéma et la documentation :
+  * [ ] espace avant les deux-points `:`
+  * [ ] apostrophe typographique `’` et non `'`
+  * [ ] accentuation
+  * ...
+* [ ] J'ai exécuté les pre-commits
+* [ ] J'ai mis à jour la documentation liée à mes changements si nécessaire
+* [ ] J'ai passé le ticket notion en review
+


### PR DESCRIPTION
Ajout d'une template de PR pour faciliter les relectures.

On peut également en spécialiser une par dossier, mais ceci est pour ouvrir la discussion avec un support.