### PR TITLE
chore(api): Make the Sentry cron monitor less paranoid

### DIFF
--- a/api/src/data_inclusion/api/inclusion_data/commands.py
+++ b/api/src/data_inclusion/api/inclusion_data/commands.py
@@ -245,7 +245,7 @@ def store_inclusion_data(
         "schedule": {"type": "crontab", "value": "0 * * * *"},
         "checkin_margin": 60,
         "max_runtime": 60,
-        "failure_issue_threshold": 1,
+        "failure_issue_threshold": 3,
         "recovery_threshold": 1,
         "timezone": "UTC",
     },


### PR DESCRIPTION
Scalingo crons are not the most reliable, and especially this one flirts with the maximum allowed execution time.

Changing the architecture of that script to make it faster is in the works but in the meantime we don't need that many alerts.

3 hours without the cron can be considered an issue though.

Pas de ticket notion.

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `api`, `pipeline`, `deployment`, `deduplication`, `datawarehouse`
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits


si ma PR concerne l'**api**

* NA J'ai réimporté les données marts depuis le datalake
* NA J'emploie le français dans l'interface de l'api (query params, description, etc.)
* NA Si ma PR inclut des modifs de l'orm, j'ai inclus les migrations alembic
* NA J'ai ajouté des tests
* NA J'ai fait une analyse perfs avant/après via locust
