### PR TITLE
chore(api): Pin data-inclusion-schema to 0.24.0

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "certifi>=2025.1.31",
     "click>=8.1.8",
     "cryptography>=44.0.2",
-    "data-inclusion-schema @ git+https://github.com/gip-inclusion/data-inclusion-schema.git@c85dcb468bff7306b573c23d6c81ef36c9f2a701",
+    "data-inclusion-schema==0.24.0",
     "fastapi>=0.115.12",
     "fastapi-pagination>=0.12.34",
     "furl>=2.1.4",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -331,7 +331,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2025.1.31" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "cryptography", specifier = ">=44.0.2" },
-    { name = "data-inclusion-schema", git = "https://github.com/gip-inclusion/data-inclusion-schema.git?rev=c85dcb468bff7306b573c23d6c81ef36c9f2a701#c85dcb468bff7306b573c23d6c81ef36c9f2a701" },
+    { name = "data-inclusion-schema", specifier = "==0.24.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "fastapi-pagination", specifier = ">=0.12.34" },
     { name = "furl", specifier = ">=2.1.4" },
@@ -375,11 +375,15 @@ test = [
 
 [[package]]
 name = "data-inclusion-schema"
-version = "0.23.0+courrielv1"
-source = { git = "https://github.com/gip-inclusion/data-inclusion-schema.git?rev=c85dcb468bff7306b573c23d6c81ef36c9f2a701#c85dcb468bff7306b573c23d6c81ef36c9f2a701" }
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pendulum" },
     { name = "pydantic", extra = ["email"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/d6/76af9cfb94b1edd74345b455c0f012f9760342a3140ea36b5ca11fdcb18c/data_inclusion_schema-0.24.0.tar.gz", hash = "sha256:9571f6cd35dc98b5c72c32775c2f85aab4feefeedfa3cf4f86d021143c1486bc", size = 23220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/e2de708e12c39eb60b11512b07354c97b5c16fce869ed3767dc652db6e92/data_inclusion_schema-0.24.0-py3-none-any.whl", hash = "sha256:39666513a91c7a97679689cf5a912a29f68f65c74f6b1f4adaf8ec9d2a9a5106", size = 27569 },
 ]
 
 [[package]]


### PR DESCRIPTION
Pas de ticket notion, c'est un fix technique.

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `api`, `pipeline`, `deployment`, `deduplication`, `datawarehouse`
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits
* NA J'ai indiqué le ticket notion associé
* NA J'ai passé le ticket notion en review


Je vérifie que la CI passe.