### PR TITLE
fix(pipeline): disable excel strings to urls

### DIFF
--- a/pipeline/dags/publish.py
+++ b/pipeline/dags/publish.py
@@ -57,7 +57,11 @@ def _publish_to_datagouv():
     to_buf_fn_by_format = {
         "json": lambda df, buf: df.to_json(buf, orient="records", force_ascii=False),
         "csv": lambda df, buf: df.to_csv(buf, index=False),
-        "xlsx": lambda df, buf: df.to_excel(buf, engine="xlsxwriter"),
+        "xlsx": lambda df, buf: df.to_excel(
+            buf,
+            engine="xlsxwriter",
+            engine_kwargs={"options": {"strings_to_urls": False}},
+        ),
         "geojson": to_geojson,
     }
 


### PR DESCRIPTION
By default, xlsxwriter casts url-like string to url and fails if the url is too long.
An url-like string is any string that starts with a scheme. Some descriptions in our dataset starts with https:// and are too long. Therefore the publication fails.