### PR TITLE
chore(pipeline): patch tarball for cve-2025-8194

### DIFF
--- a/pipeline/dags/dag_utils/sources/annuaire_du_service_public.py
+++ b/pipeline/dags/dag_utils/sources/annuaire_du_service_public.py
@@ -3,6 +3,18 @@ import tarfile
 from pathlib import Path
 
 
+# https://www.cve.org/CVERecord?id=CVE-2025-8194
+# TODO: remove this patch when the issue is fixed in tarfile
+def _block_patched(self, count):
+    if count < 0:
+        raise tarfile.InvalidHeaderError("invalid offset")
+    return _block_patched._orig_block(self, count)
+
+
+_block_patched._orig_block = tarfile.TarInfo._block
+tarfile.TarInfo._block = _block_patched
+
+
 def read(path: Path):
     import pandas as pd
 

--- a/pipeline/dags/dag_utils/sources/reseau_alpha.py
+++ b/pipeline/dags/dag_utils/sources/reseau_alpha.py
@@ -7,6 +7,19 @@ from pathlib import Path
 
 from . import utils
 
+
+# https://www.cve.org/CVERecord?id=CVE-2025-8194
+# TODO: remove this patch when the issue is fixed in tarfile
+def _block_patched(self, count):
+    if count < 0:
+        raise tarfile.InvalidHeaderError("invalid offset")
+    return _block_patched._orig_block(self, count)
+
+
+_block_patched._orig_block = tarfile.TarInfo._block
+tarfile.TarInfo._block = _block_patched
+
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
patching until https://www.cve.org/CVERecord?id=CVE-2025-8194