### PR TITLE
fix(pipeline): fix airflow image build

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,50 +1,7 @@
-########
-# This image compiles virtual environments for airflow tasks
-########
-FROM python:3.12-slim AS compile-image
-
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    build-essential \
-    libpq-dev \
-    && apt-get autoremove -yqq --purge \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY requirements requirements
-
-# virtual env path must match their location on the runtime image to be portable
-ENV VIRTUAL_ENV=/opt/airflow/venvs/python/venv
-
-RUN python -m venv ${VIRTUAL_ENV}
-RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel
-RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir -r requirements/tasks/python/requirements.txt
-
-# virtual env path must match their location on the runtime image to be portable
-ENV VIRTUAL_ENV=/opt/airflow/venvs/dbt/venv
-
-RUN python -m venv ${VIRTUAL_ENV}
-RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel
-RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir -r requirements/tasks/dbt/requirements.txt
-
-########
-# This image is the runtime
-########
 FROM apache/airflow:2.11.0-python3.12 AS runtime-image
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
-
-ENV AIRFLOW_VAR_DBT_PROJECT_DIR=/opt/airflow/dbt
-
-COPY requirements requirements
-RUN pip install -r requirements/airflow/requirements.txt
-
-# copy the compiled virtual environments to a `venvs` directory in the airflow home
-COPY --chown=airflow:0 --from=compile-image /opt/airflow/venvs /opt/airflow/venvs
 
 USER root
 
@@ -57,6 +14,25 @@ RUN apt-get update \
     && apt-get autoremove -yqq --purge \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+ENV AIRFLOW_VAR_DBT_PROJECT_DIR=/opt/airflow/dbt
+
+USER airflow
+
+COPY requirements requirements
+RUN pip install -r requirements/airflow/requirements.txt
+
+ENV VIRTUAL_ENV=/opt/airflow/venvs/python/venv
+RUN python -m venv ${VIRTUAL_ENV}
+RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir -r requirements/tasks/python/requirements.txt
+
+ENV VIRTUAL_ENV=/opt/airflow/venvs/dbt/venv
+RUN python -m venv ${VIRTUAL_ENV}
+RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir -r requirements/tasks/dbt/requirements.txt
+
+USER root
 
 RUN /opt/airflow/venvs/python/venv/bin/playwright install-deps chromium
 


### PR DESCRIPTION
There was a glibc version mismatch between the compile and runtime images. It looks like the airflow image uses an outdated glibc version. The image does not get updated as frequently as it used to, now that airflow 3 is out.

Upgrading the package manually may have been enough, but removing the compile image has been favoured as an opportunity to simplify things. Ideally the image customization should be minimal. This would make it easier to deploy airflow somewhere else.