### PR TITLE
feat(api): Enable allowing old secret's tokens

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -100,7 +100,7 @@ fastapi = ["fastapi", "fastapi_pagination"]
 markers = '''
     with_token: inject token headers in test client
     with_admin_token: inject admin token headers in test client
-    env: override settings.ENV (prod, dev, etc.)
+    settings: override api settings
     feature_deprecated: the marked test is deprecated
 '''
 testpaths = "tests"

--- a/api/src/data_inclusion/api/auth/services.py
+++ b/api/src/data_inclusion/api/auth/services.py
@@ -1,8 +1,12 @@
+import logging
+
 import jwt
 
 from data_inclusion.api.config import settings
 
 ALGORITHM = "HS256"
+
+logger = logging.getLogger(__name__)
 
 
 def create_access_token(
@@ -24,6 +28,24 @@ def verify_token(token: str) -> dict | None:
     try:
         payload = jwt.decode(jwt=token, key=settings.SECRET_KEY, algorithms=[ALGORITHM])
     except jwt.InvalidTokenError:
+        pass
+    else:
+        return payload
+
+    if settings.OLD_SECRET_KEY is None:
+        logger.info("no old secret key, aborting legacy authentication")
+        return None
+
+    try:
+        payload = jwt.decode(
+            jwt=token, key=settings.OLD_SECRET_KEY, algorithms=[ALGORITHM]
+        )
+    except jwt.InvalidTokenError:
+        return None
+
+    logger.info("old (rotated) token used by sub=%s", payload["sub"])
+
+    if payload["sub"] not in settings.OLD_USER_SUBS:
         return None
 
     return payload

--- a/api/src/data_inclusion/api/config.py
+++ b/api/src/data_inclusion/api/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     ENV: str = "prod"
     SECRET_KEY: str
+    # On 2025-04-12 this key has been rotated. We keep compatibility
+    # with existing tokens until full renewal.
+    OLD_SECRET_KEY: str | None = None
+    OLD_USER_SUBS: list[str] = []  # use JSON list in the env var
     SENTRY_DSN: str | None = None
     TOKEN_ENABLED: bool = True
 
@@ -34,3 +38,5 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+assert settings.SECRET_KEY != settings.OLD_SECRET_KEY

--- a/api/tests/e2e/api/test_openapi.py
+++ b/api/tests/e2e/api/test_openapi.py
@@ -17,10 +17,10 @@ def test_openapi_spec(api_client, snapshot):
 @pytest.mark.parametrize(
     "included_in_schema",
     [
-        pytest.param(False, id="prod", marks=[pytest.mark.env("prod")]),
-        pytest.param(True, id="staging", marks=[pytest.mark.env("staging")]),
-        pytest.param(True, id="test", marks=[pytest.mark.env("test")]),
-        pytest.param(True, id="dev", marks=[pytest.mark.env("dev")]),
+        pytest.param(False, id="prod", marks=[pytest.mark.settings(ENV="prod")]),
+        pytest.param(True, id="staging", marks=[pytest.mark.settings(ENV="staging")]),
+        pytest.param(True, id="test", marks=[pytest.mark.settings(ENV="test")]),
+        pytest.param(True, id="dev", marks=[pytest.mark.settings(ENV="dev")]),
     ],
 )
 def test_v1_include_in_schema(api_client, included_in_schema):

--- a/api/tests/unit/test_auth.py
+++ b/api/tests/unit/test_auth.py
@@ -11,6 +11,18 @@ from data_inclusion.api import auth
     [
         (None, 403),
         ("not-a-token", 403),
+        pytest.param(
+            # generated with key=legacy-key and sub=legacy.user@example.com
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJsZWdhY3kudXNlckBleGFtc"
+            "GxlLmNvbSIsImFkbWluIjpmYWxzZX0.pqDa-_YHnPlsP0v0PWROb2Bgmvz7hUaYpjH_DPSb85Y",
+            200,
+            marks=[
+                pytest.mark.settings(
+                    OLD_SECRET_KEY="legacy-key",
+                    OLD_USER_SUBS=["legacy.user@example.com"],
+                )
+            ],
+        ),
         (auth.create_access_token("some_user"), 200),
     ],
 )


### PR DESCRIPTION
Thanks to a whitelist, passed as an env var.

Ticket post-mortem.

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `api`, `pipeline`, `deployment`, `deduplication`, `datawarehouse`
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits
* [x] J'ai indiqué le ticket notion associé (sortof)
* [x] J'ai passé le ticket notion en review


si ma PR concerne l'**api**

* NA J'ai réimporté les données marts depuis le datalake
* NA J'emploie le français dans l'interface de l'api (query params, description, etc.)
* NA Si ma PR inclut des modifs de l'orm, j'ai inclus les migrations alembic
* [x] J'ai ajouté des tests
* NA J'ai fait une analyse perfs avant/après via locust
