### PR TITLE
feat(api): add origin column to search events

### DIFF
--- a/api/src/alembic/versions/20260423_081126_add_origin_to_search_events.py
+++ b/api/src/alembic/versions/20260423_081126_add_origin_to_search_events.py
@@ -1,0 +1,26 @@
+"""add origin to search services events
+
+Revision ID: add_origin_search_events
+Revises: 33b15080c36c
+Create Date: 2026-04-23 08:11:26
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "add_origin_search_events"
+down_revision = "33b15080c36c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api__search_services_events_v1",
+        sa.Column("origin", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api__search_services_events_v1", "origin")

--- a/api/src/data_inclusion/api/analytics/models.py
+++ b/api/src/data_inclusion/api/analytics/models.py
@@ -61,6 +61,7 @@ class SearchServicesEvent(db.Base):
     id: Mapped[db.uuid_pk]
     created_at: Mapped[db.timestamp]
     user: Mapped[str]
+    origin: Mapped[str | None]
     total_services: Mapped[int | None]
     sources: Mapped[list[str] | None]
     code_commune: Mapped[str | None]

--- a/api/src/data_inclusion/api/analytics/services.py
+++ b/api/src/data_inclusion/api/analytics/services.py
@@ -77,8 +77,11 @@ def save_event(
             ):
                 return
 
+            origin = request.headers.get("origin") or request.headers.get("referer")
+
             event = models.SearchServicesEvent(
                 user=user.username,
+                origin=origin,
                 total_services=first_results_page["total"],
                 sources=params.sources,
                 code_commune=params.code_commune,

--- a/api/tests/unit/test_widget.py
+++ b/api/tests/unit/test_widget.py
@@ -394,3 +394,28 @@ def test_widget_saves_search_event(api_client, db_session, auth_disabled):  # no
     ).first()
     assert event.user == "test_user"
     assert event.publics == ["femmes"]
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_origin"),
+    [
+        ({"origin": "https://example.com"}, "https://example.com"),
+        ({"referer": "https://other.com/page"}, "https://other.com/page"),
+        ({}, None),
+    ],
+    ids=["custom-origin", "custom-referer", "no-origin"],
+)
+def test_widget_saves_search_event_origin(
+    api_client,
+    db_session,
+    auth_disabled,
+    headers,
+    expected_origin,
+):
+    response = api_client.get("/widget/?token=test-token", headers=headers)
+    assert response.status_code == 200
+
+    event = db_session.scalars(
+        sqla.select(analytics_models.SearchServicesEvent)
+    ).first()
+    assert event.origin == expected_origin


### PR DESCRIPTION
Will help understand widget traffic.

[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/Ajouter-dans-les-mod-les-MB-avec-requ-tes-API-une-colonne-origine-3445f321b60480a882b9e7f82f1f9534?v=2805f321b604809380f8000c8c8995c9&source=copy_link)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `api`, `pipeline`, `deployment`, `deduplication`, `datawarehouse`
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits
* [x] J'ai indiqué le ticket notion associé
* [x] J'ai passé le ticket notion en review


si ma PR concerne l'**api**

* [x] J'ai réimporté les données marts depuis le datalake
* [x] J'emploie le français dans l'interface de l'api (query params, description, etc.)
* [x] Si ma PR inclut des modifs de l'orm, j'ai inclus les migrations alembic
* [x] J'ai ajouté des tests

