### PR TITLE
feat(api): allow pagination through explicit param even in inline mode

### DIFF
--- a/api/src/data_inclusion/api/widget/routes.py
+++ b/api/src/data_inclusion/api/widget/routes.py
@@ -189,6 +189,10 @@ def widget(
         bool,
         fastapi.Query(description="Affiche ou masque le filtre par public cible"),
     ] = True,
+    display_pagination: Annotated[
+        bool | None,
+        fastapi.Query(description="Affiche ou masque les contrôles de pagination"),
+    ] = None,
     code_commune: Annotated[
         str | None,
         fastapi.Query(
@@ -267,7 +271,9 @@ def widget(
     else:
         thematiques_for_query = list_thematiques(categories) if categories else None
 
-    inline_mode = size is not None
+    if display_pagination is None:
+        display_pagination = size is None
+
     effective_size = size if size is not None else x * y
     results = get_results(
         db_session=db_session,
@@ -319,7 +325,8 @@ def widget(
                 "page": results["page"],
                 "pages": results["pages"],
                 "x": x,
-                "inline_mode": inline_mode,
+                "inline_mode": size is not None,
+                "display_pagination": display_pagination,
             },
         )
 
@@ -346,6 +353,7 @@ def widget(
             "query_params_display_communes_filter": display_communes_filter,
             "query_params_display_categories_filter": display_categories_filter,
             "query_params_display_publics_filter": display_publics_filter,
+            "query_params_display_pagination": display_pagination,
             "query_params_sources": sources,
             "query_params_thematiques": thematiques,
             "query_params_include_remote_services": include_remote_services,
@@ -357,7 +365,8 @@ def widget(
             "page": results["page"],
             "pages": results["pages"],
             "x": x,
-            "inline_mode": inline_mode,
+            "inline_mode": size is not None,
+            "display_pagination": display_pagination,
         },
     )
 

--- a/api/src/data_inclusion/api/widget/templates/fragments/results.html
+++ b/api/src/data_inclusion/api/widget/templates/fragments/results.html
@@ -41,7 +41,7 @@
             </a>
         </div>
         <div class="di-results-footer-center">
-            {% if results and not inline_mode %}{{ pagination() }}{% endif %}
+            {% if results and display_pagination %}{{ pagination() }}{% endif %}
         </div>
         <div class="di-results-footer-right">
             <a href="https://tally.so/r/nWZBrv?produit={{ (token_sub or '')|urlencode }}&issue_url={{ current_url|urlencode }}"

--- a/api/src/data_inclusion/api/widget/templates/widget.html
+++ b/api/src/data_inclusion/api/widget/templates/widget.html
@@ -28,6 +28,9 @@
                        name="display_publics_filter"
                        value="{{ query_params_display_publics_filter|lower }}">
                 <input type="hidden"
+                       name="display_pagination"
+                       value="{{ query_params_display_pagination|lower }}">
+                <input type="hidden"
                        name="include_remote_services"
                        value="{{ query_params_include_remote_services|lower }}">
                 {% if query_params_sources %}

--- a/api/tests/unit/__snapshots__/test_widget.ambr
+++ b/api/tests/unit/__snapshots__/test_widget.ambr
@@ -51,6 +51,9 @@
                          name="display_publics_filter"
                          value="true">
                   <input type="hidden"
+                         name="display_pagination"
+                         value="true">
+                  <input type="hidden"
                          name="include_remote_services"
                          value="false">
                   
@@ -436,6 +439,9 @@
                          value="true">
                   <input type="hidden"
                          name="display_publics_filter"
+                         value="true">
+                  <input type="hidden"
+                         name="display_pagination"
                          value="true">
                   <input type="hidden"
                          name="include_remote_services"

--- a/api/tests/unit/test_widget.py
+++ b/api/tests/unit/test_widget.py
@@ -422,3 +422,27 @@ def test_widget_saves_search_event_origin(
         sqla.select(analytics_models.SearchServicesEvent)
     ).first()
     assert event.origin == expected_origin
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_pagination"),
+    [
+        ("size=1", False),
+        ("size=1&display_pagination=true", True),
+        ("x=1&y=1", True),
+        ("x=1&y=1&display_pagination=false", False),
+    ],
+)
+def test_widget_display_pagination(
+    api_client,
+    db_session,
+    auth_disabled,
+    query,
+    expected_pagination,
+):
+    factories.ServiceFactory.create_batch(3, source="dora", score_qualite=0.9)
+
+    response = api_client.get(f"/widget/?token=test-token&{query}")
+    assert response.status_code == 200
+    does_paginate = "di-pagination" in response.text
+    assert does_paginate == expected_pagination


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/Widget-modification-param-tre-sizes-x-et-y-3485f321b6048005a339c4c9e965b9fb?v=2805f321b604809380f8000c8c8995c9&source=copy_link)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
  * `<type>(<optional scope>): <description>`
  * types : `feat`, `chore`, `fix`, `docs`, etc.
  * scopes : `api`, `pipeline`, `deployment`, `deduplication`, `datawarehouse`
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits
* [x] J'ai indiqué le ticket notion associé
* [x] J'ai passé le ticket notion en review

si ma PR concerne l'**api**

* [x] J'ai réimporté les données marts depuis le datalake
* [x] J'emploie le français dans l'interface de l'api (query params, description, etc.)
* [x] J'ai ajouté des tests

<img width="2431" height="671" alt="image" src="https://github.com/user-attachments/assets/f6fdb09f-29cb-4ce2-a768-42f8dafe5d43" />
