### PR TITLE
fix(pipeline): attempt at manually setting sentry up

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -20,10 +20,8 @@ x-airflow-common:
     AIRFLOW__CORE__PARALLELISM: 4
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql://airflow:airflow@airflow-db:5432/airflow
     AIRFLOW__SCHEDULER__MAX_TIS_PER_QUERY: 0
-    AIRFLOW__SENTRY__BEFORE_SEND: data_inclusion.pipeline.common.sentry.before_send
     AIRFLOW__SENTRY__RELEASE: ${AIRFLOW__SENTRY__RELEASE}
     AIRFLOW__SENTRY__SENTRY_DSN: ${AIRFLOW__SENTRY__SENTRY_DSN}
-    AIRFLOW__SENTRY__SENTRY_ON: 'true'
     AIRFLOW__SENTRY__TRACES_SAMPLE_RATE: 0.1
     # Connections
     AIRFLOW_CONN_PG: ${AIRFLOW_CONN_PG}

--- a/pipeline/dags/data_inclusion/pipeline/common/dags.py
+++ b/pipeline/dags/data_inclusion/pipeline/common/dags.py
@@ -13,7 +13,7 @@ def common_args(use_sentry: bool = False):
     default_args = {}
 
     if use_sentry:
-        default_args["on_failure_callback"] = sentry.fill_sentry_scope
+        default_args["on_failure_callback"] = sentry.init
 
     return {
         "start_date": pendulum.datetime(2022, 1, 1, tz="Europe/Paris"),

--- a/pipeline/dags/data_inclusion/pipeline/common/sentry.py
+++ b/pipeline/dags/data_inclusion/pipeline/common/sentry.py
@@ -25,24 +25,41 @@ def before_send(event, hint):
     return event
 
 
-def fill_sentry_scope(context):
-    github_base_url = "https://github.com/gip-inclusion/data-inclusion"
+def init(context):
+    dsn = os.getenv("AIRFLOW__SENTRY__SENTRY_DSN")
+    if not dsn:
+        return
+    if not sentry_sdk.is_initialized():
+        sentry_sdk.init(
+            dsn=dsn,
+            release=os.getenv("AIRFLOW__SENTRY__RELEASE"),
+            traces_sample_rate=float(
+                os.getenv("AIRFLOW__SENTRY__TRACES_SAMPLE_RATE", "0.1")
+            ),
+            before_send=before_send,
+        )
 
-    dag_id = context.get("dag").dag_id
-    task_instance = context.get("task_instance")
-    task_id = task_instance.task_id
-    commit_sha = os.getenv("AIRFLOW__SENTRY__RELEASE", None)
+    with sentry_sdk.new_scope() as scope:
+        dag_id = context.get("dag").dag_id
+        task_id = context.get("task_instance").task_id
+        task_instance = context.get("task_instance")
+        commit_sha = os.getenv("AIRFLOW__SENTRY__RELEASE", None)
+        scope.set_tag("dag_id", dag_id)
+        scope.set_tag("task_id", task_id)
 
-    scope = sentry_sdk.get_current_scope()
-    scope.set_tag("dag_id", dag_id)
-    scope.set_tag("task_id", task_id)
-    # Fine-tune the fingerprint to force de-grouping issues if not from
-    # the same DAG
-    scope.fingerprint = ["{{ default }}", dag_id]
-    scope.set_context(
-        "custom",
-        {
-            "airflow_logs_url": task_instance.log_url,
-            "github_commit_url": f"{github_base_url}/commit/{commit_sha}",
-        },
-    )
+        # Fine-tune the fingerprint to force de-grouping issues if not from
+        # the same DAG
+        scope.fingerprint = ["{{ default }}", dag_id]
+        scope.set_context(
+            "custom",
+            {
+                "airflow_logs_url": task_instance.log_url,
+                "github_commit_url": (
+                    "https://github.com/gip-inclusion/"
+                    f"data-inclusion/commit/{commit_sha}"
+                ),
+            },
+        )
+
+        sentry_sdk.capture_exception(context.get("exception"))
+        sentry_sdk.flush(timeout=5)


### PR DESCRIPTION
I don't really understand why sentry does still not work but I want to try setting it up manually, it won't be worse than now

So I disable the native integration and use DAG context to send to sentry thanks to the basic sentry_sdk API

It's very close to what we had before switching to airlfow v3
