### PR TITLE
fix(api): améliorer la recherche full text sur les phrases à plusieurs mots

### DIFF
--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -402,15 +402,26 @@ def search_query(
     score_recherche_expr = None
     if params.q is not None:
         plainto_tsquery = sqla.func.plainto_tsquery("public.french", params.q)
+        score_expr = sqla.func.ts_rank_cd(
+            models.Service.search_vector, plainto_tsquery, 32
+        )
+
+        # apply a "phrase" extra bonus (rewarding exact word order and adjacence)
+        # when we have multiple words in the query. word closeness still counts
+        # with score_expr.
+        if len(params.q.split()) > 1:
+            phraseto_tsquery = sqla.func.phraseto_tsquery("public.french", params.q)
+            phrase_rank = sqla.func.ts_rank_cd(
+                models.Service.search_vector,
+                phraseto_tsquery,
+                32,
+            )
+            # weight of 2 allows for exact adjacent match to be guaranteed first
+            # without completely discarding ts_rank_cd matches
+            score_expr = score_expr + 2 * phrase_rank
+
         score_recherche_expr = sqla.func.round(
-            sqla.cast(
-                sqla.func.ts_rank_cd(
-                    models.Service.search_vector,
-                    plainto_tsquery,
-                    32,
-                ),
-                sqla.Numeric,
-            ),
+            sqla.cast(score_expr, sqla.Numeric),
             2,
         ).label("score_recherche")
 

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -1734,3 +1734,83 @@ def test_search_order_by_distance(api_client):
     assert response.status_code == 200
     items = response.json()["items"]
     assert [item["data"]["id"] for item in items] == ["closer", "farther"]
+
+
+@pytest.mark.with_token
+@pytest.mark.parametrize(
+    ("services", "expected_ordered_ids"),
+    [
+        pytest.param(
+            [
+                {
+                    "id": "phrase",
+                    "structure__nom": "Action Logement Solidarités",
+                    "score_qualite": 0.5,
+                },
+                {
+                    "id": "scattered",
+                    "structure__nom": "Logement social et action immédiate",
+                    "score_qualite": 0.5,
+                },
+            ],
+            ["phrase", "scattered"],
+            id="des mots adjacents surclassent un ordre dispersé",
+        ),
+        pytest.param(
+            [
+                {
+                    "id": "phrase",
+                    "structure__nom": "Action Logement Solidarités",
+                    "score_qualite": 0.1,
+                },
+                {
+                    "id": "scattered",
+                    "structure__nom": "Logement social et action immédiate",
+                    "score_qualite": 1.0,
+                },
+            ],
+            ["phrase", "scattered"],
+            id="le bonus de phrase surpasse le bonus de qualité",
+        ),
+        pytest.param(
+            [
+                {
+                    "id": "phrase",
+                    "structure__nom": "Action Logement Services",
+                    "score_qualite": 0.5,
+                },
+                {
+                    "id": "reversed",
+                    "structure__nom": "Logement Action Services",
+                    "score_qualite": 0.5,
+                },
+            ],
+            ["phrase", "reversed"],
+            id="l'ordre de phrase compte",
+        ),
+        pytest.param(
+            [
+                {
+                    "id": "scattered",
+                    "structure__nom": "Foo",
+                    "description": (
+                        "Nous proposons une action d'accompagnement social "
+                        "et un appui à la recherche de logement."
+                    ),
+                    "score_qualite": 0.5,
+                },
+            ],
+            ["scattered"],
+            id="ordre dispersé retourné malgré tout",
+        ),
+    ],
+)
+def test_search_phrase_boost(api_client, services, expected_ordered_ids):
+    for kwargs in services:
+        factories.ServiceFactory(**kwargs)
+
+    response = api_client.get(SEARCH_ENDPOINT.url, params={"q": "action logement"})
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["data"]["id"] for item in items] == expected_ordered_ids


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://www.notion.so/gip-inclusion/DEV-Conception-de-la-logique-recherche-sur-d-i-3495f321b60480efaa5ceb0bbceb7e87?source=copy_link)

Petite modification pour prendre en compte [la remarque de Antoine](https://www.notion.so/DEV-Conception-de-la-logique-recherche-sur-d-i-3495f321b60480efaa5ceb0bbceb7e87?d=3595f321b60480d4974a001c3e7d87a3&source=copy_link#3595f321b6048093b198e19d9e0d1352) mais bon après je pense que il faut stopper le fine tuning à un moment peut etre