### PR TITLE
feat(api): Rename /search result field to "service"

### DIFF
--- a/api/src/data_inclusion/api/inclusion_data/schemas.py
+++ b/api/src/data_inclusion/api/inclusion_data/schemas.py
@@ -125,6 +125,6 @@ class ListedStructure(Structure):
 
 
 class SearchResult(BaseModel):
-    data: DetailedService | DetailedStructure
+    service: DetailedService | DetailedStructure
     distance: int | None = None
     score_recherche: float | None = None

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -453,7 +453,7 @@ def search_query(
     else:
         query = query.add_columns(sqla.null().cast(sqla.Integer).label("distance"))
 
-    return query, ("data", "score_recherche", "distance")
+    return query, ("service", "score_recherche", "distance")
 
 
 def build_search_index(

--- a/api/tests/e2e/api/__snapshots__/test_openapi.ambr
+++ b/api/tests/e2e/api/__snapshots__/test_openapi.ambr
@@ -2138,17 +2138,6 @@
         },
         "SearchResult": {
           "properties": {
-            "data": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/DetailedService"
-                },
-                {
-                  "$ref": "#/components/schemas/DetailedStructure"
-                }
-              ],
-              "title": "Data"
-            },
             "distance": {
               "anyOf": [
                 {
@@ -2170,10 +2159,21 @@
                 }
               ],
               "title": "Score Recherche"
+            },
+            "service": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/DetailedService"
+                },
+                {
+                  "$ref": "#/components/schemas/DetailedStructure"
+                }
+              ],
+              "title": "Service"
             }
           },
           "required": [
-            "data"
+            "service"
           ],
           "title": "SearchResult",
           "type": "object"

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -1510,7 +1510,7 @@ def test_search_score_recherche_between_zero_and_one(api_client):
     response_data = response.json()
 
     assert len(response_data["items"]) == 1
-    assert "data" in response_data["items"][0]
+    assert "service" in response_data["items"][0]
     assert "score_recherche" in response_data["items"][0]
     assert 0 < response_data["items"][0]["score_recherche"] < 1
 
@@ -1528,8 +1528,8 @@ def test_search_score_recherche_decreasing(api_client):
     response_data = response.json()
 
     assert len(response_data["items"]) == 2
-    assert response_data["items"][0]["data"]["id"] == service_1.id
-    assert response_data["items"][1]["data"]["id"] == service_2.id
+    assert response_data["items"][0]["service"]["id"] == service_1.id
+    assert response_data["items"][1]["service"]["id"] == service_2.id
     # score_recherche must decrease
     assert (
         response_data["items"][0]["score_recherche"]
@@ -1626,8 +1626,8 @@ def test_search_weights(api_client, q, left, right, op):
     assert len(response_data["items"]) == 2
 
     if op != operator.eq:
-        assert response_data["items"][0]["data"]["id"] == service_1.id
-        assert response_data["items"][1]["data"]["id"] == service_2.id
+        assert response_data["items"][0]["service"]["id"] == service_1.id
+        assert response_data["items"][1]["service"]["id"] == service_2.id
     assert op(
         response_data["items"][0]["score_recherche"],
         response_data["items"][1]["score_recherche"],
@@ -1660,7 +1660,7 @@ def test_search_order_by_score_recherche_then_by_score_qualite(api_client):
     response = api_client.get(SEARCH_ENDPOINT.url, params={"q": "France travail Paris"})
 
     assert response.status_code == 200
-    assert [item["data"]["id"] for item in response.json()["items"]] == [
+    assert [item["service"]["id"] for item in response.json()["items"]] == [
         "2",
         "1",
         "4",
@@ -1710,7 +1710,7 @@ def test_search_distance_filter(api_client, params, expected_ids):
     response = api_client.get(SEARCH_ENDPOINT.url, params=params)
 
     assert response.status_code == 200
-    assert {item["data"]["id"] for item in response.json()["items"]} == expected_ids
+    assert {item["service"]["id"] for item in response.json()["items"]} == expected_ids
 
 
 @pytest.mark.with_token
@@ -1733,4 +1733,4 @@ def test_search_order_by_distance(api_client):
 
     assert response.status_code == 200
     items = response.json()["items"]
-    assert [item["data"]["id"] for item in items] == ["closer", "farther"]
+    assert [item["service"]["id"] for item in items] == ["closer", "farther"]


### PR DESCRIPTION
Objectif : être plus cohérent avec la route `/search/services`, afin de permettre aux clients (ex. DORA) de mutualiser le code traitant les résultats de l’API.

L’API étant en BETA, ne pas utiliser, je me dis qu’il est encore temps de se faciliter la vie ?

si ma PR concerne l'**api**

* [ ] J'ai réimporté les données marts depuis le datalake
* [x] J'emploie le français dans l'interface de l'api (query params, description, etc.)
* [x] J'ai ajouté des tests
* [ ] J'ai fait une analyse perfs avant/après via locust -- probablement pas nécessaire
