### PR TITLE
search: make it resilient against mistypes

### DIFF
--- a/api/src/alembic/versions/20260728_182605_add_search_lexicon.py
+++ b/api/src/alembic/versions/20260728_182605_add_search_lexicon.py
@@ -1,0 +1,58 @@
+"""add search lexicon
+
+Revision ID: 6f1b0c4a72de
+Revises: ad210f4de5ee
+Create Date: 2026-07-28 18:26:05.155560
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6f1b0c4a72de"
+down_revision = "ad210f4de5ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    # may be missing if the init migration was skipped (e.g. staging)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_ts_config c
+                JOIN pg_namespace n ON n.oid = c.cfgnamespace
+                WHERE n.nspname = 'public' AND c.cfgname = 'french'
+            ) THEN
+                CREATE TEXT SEARCH CONFIGURATION public.french (
+                    COPY = pg_catalog.french
+                );
+            END IF;
+        END $$;
+        ALTER TEXT SEARCH CONFIGURATION public.french
+            ALTER MAPPING FOR hword, hword_part, word
+                WITH unaccent, french_stem;
+    """)
+    op.create_table(
+        "api__search_lexicon_v1",
+        sa.Column("word", sa.String(), nullable=False),
+        sa.Column("ndoc", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("word", name=op.f("pk_api__search_lexicon_v1")),
+    )
+    op.create_index(
+        op.f("ix_api__search_lexicon_v1__word"),
+        "api__search_lexicon_v1",
+        ["word"],
+        unique=False,
+        postgresql_using="gin",
+        postgresql_ops={"word": "gin_trgm_ops"},
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api__search_lexicon_v1")

--- a/api/src/data_inclusion/api/inclusion_data/routes.py
+++ b/api/src/data_inclusion/api/inclusion_data/routes.py
@@ -231,6 +231,7 @@ def search_endpoint(
         3. description service et structure
     """
     query, mapping = services.search_query(
+        db_session=db_session,
         params=params,
         include_soliguide=soliguide.is_allowed_user(request),
     )

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -561,14 +561,14 @@ def build_search_index(
         )
         UPDATE api__services_v1
         SET search_vector =
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.nom,              '')), 'A') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(thematiques.labels,                  '')), 'A') ||
             SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.nom,                '')), 'A') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(thematiques.labels,                  '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(publics.labels,                      '')), 'B') ||
             SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(reseaux_porteurs.labels,             '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.publics_precisions, '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.description,        '')), 'C') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.description,      '')), 'C')
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.nom,              '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.description,        '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.description,      '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(publics.labels,                      '')), 'C') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.publics_precisions, '')), 'C')
         FROM api__structures_v1
         LEFT JOIN thematiques ON TRUE
         LEFT JOIN publics ON TRUE

--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import geoalchemy2
 import sqlalchemy as sqla
 from sqlalchemy import orm
+from sqlalchemy.dialects.postgresql import TSQUERY
 
 from data_inclusion.api.decoupage_administratif import constants
 from data_inclusion.api.decoupage_administratif.models import Commune
@@ -370,7 +371,68 @@ def retrieve_service(
     ).scalar_one_or_none()
 
 
+def search_tsquery(db_session: orm.Session, q: str) -> sqla.ColumnElement:
+    """A typo-tolerant tsquery.
+
+    Method recommended by the pg_trgm doc
+    https://www.postgresql.org/docs/18/pgtrgm.html#PGTRGM-TEXT-SEARCH
+    It needs a lexicon of words and their frequency in the database, here
+    `api__search_lexicon_v1`, filled by `build_search_index`
+
+    PG indexes lexemes, ie roots without accent or ending:
+    "GARAGE Solidaire" becomes "garag" and "solidair".
+    An error in the query or in the database gives a different lexeme
+    such as "solidiar", which matches nothing.
+    So we look for "close enough" lexemes through trigrams
+    """
+    tsquery = db_session.execute(
+        sqla.text("""
+            SELECT STRING_AGG('(' || expansion.variants || ')', ' & ')
+            FROM UNNEST(
+                TSVECTOR_TO_ARRAY(TO_TSVECTOR('public.french', :q))
+            ) AS lexeme
+            LEFT JOIN api__search_lexicon_v1 AS entry ON entry.word = lexeme
+            CROSS JOIN LATERAL (
+                SELECT STRING_AGG(QUOTE_LITERAL(word), '|') AS variants
+                FROM (
+                    SELECT lexeme AS word
+                    UNION
+                    (SELECT word
+                        FROM api__search_lexicon_v1
+                        WHERE COALESCE(entry.ndoc, 0) < :max_ndoc
+                            AND LENGTH(lexeme) >= :min_length
+                            AND word % lexeme
+                        ORDER BY
+                            SIMILARITY(word, lexeme) + :freq_weight * LN(ndoc + 1)
+                            DESC
+                        LIMIT :variants
+                    )
+                ) AS candidates
+            ) AS expansion
+        """),
+        {
+            "q": q,
+            # NOTE: those thresholds have been found though data analysis
+            # a word found in more than 100 services is probably legit
+            # FYI the most widespread typo in the database "illetr" is found
+            # in 37 services
+            "max_ndoc": 100,
+            # keep at most 4 variants of each lexeme
+            "variants": 4,
+            # leans towards common words.
+            # Lower it and "solidiar" picks "solidiair" which is a typo
+            # Increase it and a correct but rare word no longer comes up
+            "freq_weight": 0.05,
+            # do not find close lexemes for words shorter than 4 characters
+            "min_length": 4,
+        },
+    ).scalar()
+
+    return sqla.cast(tsquery or "", TSQUERY)
+
+
 def search_query(
+    db_session: orm.Session,
     params: parameters.SearchQueryParams,
     include_soliguide: bool,
 ) -> tuple[sqla.Select[tuple[models.Service, int]], tuple[str, str, str]]:
@@ -401,12 +463,12 @@ def search_query(
 
     score_recherche_expr = None
     if params.q is not None:
-        plainto_tsquery = sqla.func.plainto_tsquery("public.french", params.q)
+        tsquery = search_tsquery(db_session=db_session, q=params.q)
         score_recherche_expr = sqla.func.round(
             sqla.cast(
                 sqla.func.ts_rank_cd(
                     models.Service.search_vector,
-                    plainto_tsquery,
+                    tsquery,
                     32,
                 ),
                 sqla.Numeric,
@@ -414,9 +476,7 @@ def search_query(
             2,
         ).label("score_recherche")
 
-        query = query.filter(
-            models.Service.search_vector.bool_op("@@")(plainto_tsquery)
-        )
+        query = query.filter(models.Service.search_vector.bool_op("@@")(tsquery))
         query = query.add_columns(score_recherche_expr)
         query = query.order_by((sqla.func.round(score_recherche_expr * 10) / 2).desc())
     else:
@@ -520,4 +580,15 @@ def build_search_index(
             AND types.service_id = api__services_v1.id
     """)  # noqa: E501
     )
+
+    # refill the lexeme/frequency lexicon
+    db_session.execute(
+        sqla.text("""
+        TRUNCATE api__search_lexicon_v1;
+        INSERT INTO api__search_lexicon_v1 (word, ndoc)
+        SELECT word, ndoc
+        FROM TS_STAT('SELECT search_vector FROM api__services_v1')
+    """)
+    )
+
     db_session.commit()

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -1569,6 +1569,7 @@ def test_search_by_(api_client, field, value, q, expected):
             # this prevent flaky tests due to the default
             # factory values matching the search query
             "description": "lorem ipsum dolor sit amet",
+            "structure__description": "lorem ipsum dolor sit amet",
             **{field: value},
         },
     )
@@ -1686,6 +1687,26 @@ def test_search_accents(api_client, nom_structure, q):
     response_data = response.json()
 
     assert len(response_data["items"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("noms_structures", "q", "n_expected_matches"),
+    [
+        (["lutte contre l'illettrisme"], "illetrisme", 1),
+        (["garage solidaire"], "garage solidiare", 1),
+        # the typed lexeme is kept: services already containing the typo are found
+        (["illettrisme", "illetrisme"], "illetrisme", 2),
+    ],
+)
+@pytest.mark.with_token
+def test_search_typos(api_client, noms_structures, q, n_expected_matches):
+    for nom_structure in noms_structures:
+        factories.ServiceFactory(structure__nom=nom_structure)
+
+    response = api_client.get(SEARCH_ENDPOINT.url, params={"q": q})
+
+    assert response.status_code == 200
+    assert len(response.json()["items"]) == n_expected_matches
 
 
 @pytest.mark.with_token

--- a/api/tests/e2e/api/test_inclusion_data.py
+++ b/api/tests/e2e/api/test_inclusion_data.py
@@ -1588,17 +1588,17 @@ def test_search_by_(api_client, field, value, q, expected):
     [
         pytest.param(
             "foo",
-            {"structure__nom": "foo", "nom": "bar"},
             {"structure__nom": "bar", "nom": "foo"},
-            operator.eq,
-            id="match on structure__nom stronger than match on nom",
+            {"structure__nom": "foo", "nom": "bar"},
+            operator.ge,
+            id="match on nom stronger than match on structure__nom",
         ),
         pytest.param(
             "foo",
             {"structure__nom": "foo", "description": "lorem ipsum dolor sit amet bar"},
             {"structure__nom": "bar", "description": "lorem ipsum dolor sit amet foo"},
-            operator.ge,
-            id="match on structure__nom stronger than match on description",
+            operator.eq,
+            id="match on structure__nom equal to match on description",
         ),
         pytest.param(
             "foo",
@@ -1610,8 +1610,21 @@ def test_search_by_(api_client, field, value, q, expected):
                 "structure__nom": "bar",
                 "structure__description": "lorem ipsum dolor sit amet foo",
             },
+            operator.eq,
+            id="match on structure__nom equal to match on structure__description",
+        ),
+        pytest.param(
+            "Soutien aux aidants",
+            {
+                "thematiques": [v1.Thematique.FAMILLE__SOUTIEN_AIDANTS.value],
+                "structure__nom": "bar",
+            },
+            {
+                "thematiques": [v1.Thematique.SANTE__ACCES_AUX_SOINS.value],
+                "structure__nom": "Soutien aux aidants",
+            },
             operator.ge,
-            id="match on structure__nom stronger than match on structure__description",
+            id="match on thematiques stronger than match on structure__nom",
         ),
     ],
 )


### PR DESCRIPTION
[Lien vers le ticket notion associé](https://app.notion.com/p/gip-inclusion/Investigation-sur-les-fautes-de-frappe-sur-le-param-tre-q-de-la-recherche-par-mots-cl-s-3aa5f321b604809ca5acd16b5797a1c4?v=2805f321b604809380f8000c8c8995c9&source=copy_link)
