### PR TITLE
refactor(searh_vector): modify fields weight for the new search route

### DIFF
--- a/api/src/data_inclusion/api/inclusion_data/services.py
+++ b/api/src/data_inclusion/api/inclusion_data/services.py
@@ -501,14 +501,14 @@ def build_search_index(
         )
         UPDATE api__services_v1
         SET search_vector =
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.nom,              '')), 'A') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(thematiques.labels,                  '')), 'A') ||
             SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.nom,                '')), 'A') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(thematiques.labels,                  '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(publics.labels,                      '')), 'B') ||
             SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(reseaux_porteurs.labels,             '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.publics_precisions, '')), 'B') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.description,        '')), 'C') ||
-            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.description,      '')), 'C')
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.nom,              '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.description,        '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__structures_v1.description,      '')), 'B') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(publics.labels,                      '')), 'C') ||
+            SETWEIGHT(TO_TSVECTOR('public.french', COALESCE(api__services_v1.publics_precisions, '')), 'C')
         FROM api__structures_v1
         LEFT JOIN thematiques ON TRUE
         LEFT JOIN publics ON TRUE


### PR DESCRIPTION
Reweight the `search_vector` in `build_search_index()` to align with actual user search behavior observed during the Dora search A/B test (experiment #17).

[Lien vers le ticket notion associé](https://app.notion.com/p/gip-inclusion/Recherche-par-mots-cl-s-Am-liorer-search_vector-3aa5f321b604808db524d7a4c5511ea4?source=copy_link)

### Check-list

* [x] Mes commits et ma PR suivent le [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* [x] Mes messages de commit sont en anglais
* [x] J'ai exécuté les pre-commits
* [x] J'ai indiqué le ticket notion associé
* [x] J'ai passé le ticket notion en review